### PR TITLE
Assert equality of span tags. Fixed two tests to check top-level tags.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -50,7 +50,7 @@ public class TestServerWebServices {
     /**
      * Async web service endpoint that creates local span.
      */
-    public static final String REST_ASYNC_LOCAL_SPAN = "asuncLocalSpan";
+    public static final String REST_ASYNC_LOCAL_SPAN = "asyncLocalSpan";
 
     @Inject
     private Tracer tracer;
@@ -72,7 +72,7 @@ public class TestServerWebServices {
     @Path(REST_LOCAL_SPAN)
     @Produces(MediaType.TEXT_PLAIN)
     public Response localSpan() {
-        tracer.buildSpan("localSpan").start().finish();
+        tracer.buildSpan("localSpan").startManual().finish();
         return Response.ok().build();
     }
 
@@ -83,7 +83,7 @@ public class TestServerWebServices {
     @Path(REST_ASYNC_LOCAL_SPAN)
     @Produces(MediaType.TEXT_PLAIN)
     public void asyncLocalSpan(@Suspended final AsyncResponse asyncResponse) {
-        tracer.buildSpan("localSpan").start().finish();
+        tracer.buildSpan("localSpan").startManual().finish();
         asyncResponse.resume(Response.ok().build());
     }
 }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpanTree.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpanTree.java
@@ -188,7 +188,7 @@ public class TestSpanTree {
                     return false;
                 }
                 if (otherNode.children.size() != children.size()) {
-                    System.out.println("Child span counts don't match: "
+                    System.err.println("MISMATCH: Child span counts don't match: "
                             + children.size() + " ; "
                             + otherNode.children.size());
                     return false;
@@ -245,7 +245,7 @@ public class TestSpanTree {
         TestSpanTree otherTree = (TestSpanTree) obj;
         if (otherTree != null) {
             if (otherTree.rootSpans.size() != rootSpans.size()) {
-                System.out.println("Root span counts don't match: "
+                System.err.println("MISMATCH: Root span counts don't match: "
                         + rootSpans.size() + " ; "
                         + otherTree.rootSpans.size());
                 return false;


### PR DESCRIPTION
Also added debug capabilities to Arquillian client and make debugging easier by clearing the tracer before each test.

Signed-off-by: Kevin Grigorenko <kevin.grigorenko@us.ibm.com>