### PR TITLE
Improve typography, Use OpenTracing

### DIFF
--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -92,7 +92,8 @@ In order to make MicroProfile as flexible as possible for adding distributed tra
 
 This specification defines an easy way to allow an application running in a
 MicroProfile container to take advantage of distributed tracing by using an
-OpenTracing Tracer implementation.
+OpenTracing Tracer implementation. This document and implementations MUST comply with
+OpenTracing specification and semantic conventions if it is not defined otherwise.
 
 There are two operation modes
 
@@ -139,7 +140,7 @@ Spans created for incoming requests will have the following tags added by defaul
 
 `Tags.SPAN_KIND` MUST be specified at Span start time.
 
-An https://github.com/opentracing/specification/blob/master/semantic_conventions.md[Tags.ERROR tag] SHOULD be added to a Span on failed operations for any server error (5xx) codes.
+`Tags.ERROR tag` SHOULD be added to a Span on failed operations for any server error (5xx) codes.
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 ==== Span creation and injection for outbound requests
@@ -162,7 +163,7 @@ Spans created for outgoing requests will have the following tags added by defaul
 
 `Tags.SPAN_KIND` MUST be specified at Span start time.
 
-An https://github.com/opentracing/specification/blob/master/semantic_conventions.md[Tags.ERROR tag] SHOULD be added to a Span on failed operations for any client error (4xx) codes.
+`Tags.ERROR` tag SHOULD be added to a Span on failed operations for any client error (4xx) codes.
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 === Enabling explicit distributed tracing code instrumentation
@@ -188,7 +189,7 @@ When the `@Traced(false)` annotation is used for a JAX-RS endpoint method, the u
 
 * `operationName=<Name for the Span>`.
 Default is `""`.
-If the `@Traced` annotation finds the operationName as `""`, the default operation name is used. For a JAX-RS endpoint method (see <<server-span-name>>).
+If the `@Traced` annotation finds the `operationName` as `""`, the default operation name is used. For a JAX-RS endpoint method (see <<server-span-name>>).
 If the annotated method is not a JAX-RS endpoint, the default operation name of the new Span for the method is
 ```
 <package name>.<class name>.<method name>

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -47,7 +47,7 @@ Distributed tracing allows you to trace the flow of a request across service bou
 This is particularly important in a microservices environment where a request typically flows through multiple services.
 To accomplish distributed tracing, each service must be instrumented to log messages with a correlation id that may have been propagated from an upstream service.
 A common companion to distributed trace logging is a service where the distributed trace records can be stored.
-See also http://opentracing.io/documentation/pages/supported-tracers.html[Examples on opentracing.io].
+See also examples on http://opentracing.io/documentation/pages/supported-tracers.html[opentracing.io].
 The storage service for distributed trace records can provide features to view the cross service trace records associated with particular request flows.
 
 It will be useful for services written in the MicroProfile framework to be able to integrate well with a distributed trace system that is part of the larger microservices environment.
@@ -56,14 +56,14 @@ This specification defines an API and MicroProfile behaviors that allow services
 This specification specifically addresses the problem of making it easy to instrument services with distributed tracing function, given an existing distributed tracing system in the environment.
 
 This specification specifically does not address the problem of defining, implementing, or configuring the underlying distributed tracing system.
-The proposal assumes an environment where all services use a common opentracing.io implementation (all zipkin compatible, all jaeger compatible, ...).
+The proposal assumes an environment where all services use a common OpenTracing implementation (all Zipkin compatible, all Jaeger compatible, ...).
 
 The information about a Span that is propagated between services is typically called a SpanContext.
 It is not the intent of this specification to define the exact format for how SpanContext information is stored or propagated.
 Our use case is for applications running in an environment where all applications use the same Tracer implementation,
-and microservices that require explicit tracing logic use the opentracing API.
-Work on defining common formats for SpanContexts and implementations that use the common format is being done at https://github.com/census-instrumentation/opencensus-java[open-census].
-The open-census API appears very similar to opentracing, but support for open-census Tracers will probably require a separate MicroProfile specification.
+and microservices that require explicit tracing logic use the OpenTracing API.
+Work on defining common formats for SpanContexts and implementations that use the common format is being done at http://opencensus.io/[OpenCensus].
+The OpenCensus API appears very similar to OpenTracing, but support for OpenCensus Tracers will probably require a separate MicroProfile specification.
 
 == Rationale
 
@@ -79,20 +79,20 @@ Without the second, custom code would need to be written to present the informat
 There are existing distributed tracing systems that provide a server for distributed trace record storage and viewing, and application libraries for instrumenting microservices.
 The problem is that the different distributed tracing systems use implementation specific mechanisms for propagating correlation IDs and for formatting trace records, so once a microservice chooses a distributed tracing implementation library to use for its instrumentation, all other microservices in the environment are locked into the same choice.
 
-The http://opentracing.io/[opentracing.io project's] purpose is to provide a standard API for instrumenting microservices for distributed tracing.
-If every microservice is instrumented for distributed tracing using the opentracing.io API, then (as long as an implementation library exists for the microservice's language), the microservice can be configured at deploy time to use a common system implementation to perform the log record formatting and cross service correlation id propagation.
+The http://opentracing.io/[OpenTracing] project's purpose is to provide a standard API for instrumenting microservices for distributed tracing.
+If every microservice is instrumented for distributed tracing using the OpenTracing API, then (as long as an implementation library exists for the microservice's language), the microservice can be configured at deploy time to use a common system implementation to perform the log record formatting and cross service correlation id propagation.
 The common implementation ensures that correlation ids are propagated in a way that is understandable to all services, and log records are formatted in a way that is understandable to the server for distributed trace record storage.
 
 In order to make MicroProfile distributed tracing friendly, it will be useful to allow distributed tracing to be enabled on any MicroProfile application, without having to explicitly add distributed tracing code to the application.
 
-In order to make MicroProfile as flexible as possible for adding distributed trace log records, MicroProfile should expose whatever objects are necessary for an application to use the opentracing.io API.
+In order to make MicroProfile as flexible as possible for adding distributed trace log records, MicroProfile should expose whatever objects are necessary for an application to use the OpenTracing API.
 
 
 == Architecture
 
 This specification defines an easy way to allow an application running in a
 MicroProfile container to take advantage of distributed tracing by using an
-opentracing.io Tracer implementation.
+OpenTracing Tracer implementation.
 
 There are two operation modes
 
@@ -104,24 +104,22 @@ There are two operation modes
 
 The MicroProfile implementation will allow JAX-RS applications to participate in distributed tracing, without requiring developers to add any distributed tracing code into their applications, and without requiring developers to know anything about the distributed tracing environment that their JAX-RS application will be deployed into.
 
-1. The MicroProfile implementation must provide a mechanism to configure an io.opentracing.Tracer implementation for use by each JAX-RS application.
+1. The MicroProfile implementation must provide a mechanism to configure an `io.opentracing.Tracer` implementation for use by each JAX-RS application.
 2. The MicroProfile implementation must provide a mechanism to automatically extract SpanContext information from any incoming JAX-RS request.
 3. The MicroProfile implementation must provide a mechanism to automatically start a Span for any incoming JAX-RS request, and finish the Span when the request completes.
 4. The MicroProfile implementation must provide a mechanism to automatically inject SpanContext information into any outgoing JAX-RS request.
 5. The MicroProfile implementation must provide a mechanism to automatically start a Span for any outgoing JAX-RS request, and finish the Span when the request completes.
 
 Correct parent child relationships between incoming requests and outgoing requests are handled automatically, as long as the outgoing requests occur on the same thread as the incoming request.
-If outgoing requests are performed on a different thread than the incoming request, it is the developers responsibility to propagate the Tracer context between threads. 
+If outgoing requests are performed on a different thread than the incoming request, it is the developers responsibility to propagate the Tracer context between threads.
 
 ==== Tracer configuration
 An implementation of an `io.opentracing.Tracer` must be made available to each application. Each application will have its own Tracer instance.
 The Tracer must be configurable outside of the application to match the distributed tracing environment where the application is deployed. For example, it should be possible to take the exact same application and deploy it to an environment where Zipkin is in use, and to deploy the application without modification to a different environment where Jaeger is in use, and the application should report Spans correctly in either environment.
 
-==== SpanContext extraction
-When a request arrives at a JAX-RS endpoint, an attempt is made to use the configured Tracer to extract a SpanContext from the arriving request. If a SpanContext is extracted, it is used as the parent for the new Span that is created for the endpoint.
-
 ==== Span creation for inbound requests
-When a request arrives at a JAX-RS endpoint, a new Span is created. The new Span will be a child of the SpanContext extracted from the incoming request, if the extracted SpanContext exists.
+When a request arrives at a JAX-RS endpoint, configured Tracer instance is used to extract a SpanContext from the
+inbound request. The extracted context is used as a child of reference for a new Span created for this endpoint.
 
 [[server-span-name]]
 ===== Server Span name
@@ -133,19 +131,19 @@ The default operation name of the new Span for the incoming request is
 ===== Server Span tags
 Spans created for incoming requests will have the following tags added by default:
 
-* Tags.SPAN_KIND = Tags.SPAN_KIND_SERVER
-* Tags.HTTP_METHOD
-* Tags.HTTP_URL
-* Tags.HTTP_STATUS
-* Tags.ERROR (if true)
+* `Tags.SPAN_KIND = Tags.SPAN_KIND_SERVER`
+* `Tags.HTTP_METHOD`
+* `Tags.HTTP_URL`
+* `Tags.HTTP_STATUS`
+* `Tags.ERROR` (if true)
 
-Tags.SPAN_KIND MUST be specified at Span start time.
+`Tags.SPAN_KIND` MUST be specified at Span start time.
 
 An https://github.com/opentracing/specification/blob/master/semantic_conventions.md[Tags.ERROR tag] SHOULD be added to a Span on failed operations for any server error (5xx) codes.
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 ==== Span creation and injection for outbound requests
-When a request is sent from a JAX-RS javax.ws.rs.client.Client, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
+When a request is sent from a JAX-RS `javax.ws.rs.client.Client`, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
 
 ===== Client Span name
 The default operation name of the new Span for the outgoing request is
@@ -156,13 +154,13 @@ The default operation name of the new Span for the outgoing request is
 ===== Client Span tags
 Spans created for outgoing requests will have the following tags added by default:
 
-* Tags.SPAN_KIND = Tags.SPAN_KIND_CLIENT
-* Tags.HTTP_METHOD
-* Tags.HTTP_URL
-* Tags.HTTP_STATUS
-* Tags.ERROR (if true)
+* `Tags.SPAN_KIND = Tags.SPAN_KIND_CLIENT`
+* `Tags.HTTP_METHOD`
+* `Tags.HTTP_URL`
+* `Tags.HTTP_STATUS`
+* `Tags.ERROR` (if true)
 
-Tags.SPAN_KIND MUST be specified at Span start time.
+`Tags.SPAN_KIND` MUST be specified at Span start time.
 
 An https://github.com/opentracing/specification/blob/master/semantic_conventions.md[Tags.ERROR tag] SHOULD be added to a Span on failed operations for any client error (4xx) codes.
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
@@ -173,7 +171,7 @@ An annotation is provided to define explicit Span creation. This works on top of
 
 * `@Traced`: Specify a class or method to be traced.
 
-==== The @Traced annotation
+==== The traced annotation
 
 The `@Traced` annotation, applies to a class or a method. When applied to a class, the `@Traced` annotation is applied to all methods of the class.
 If the annotation is applied to a class and method then the annotation applied to the method takes precedence.
@@ -181,16 +179,16 @@ The annotation starts a Span at the beginning of the method, and finishes the Sp
 
 The `@Traced` annotation has two optional arguments.
 
-* value=[true|false]. Defaults to true.
+* `value=[true|false]`. Defaults to true.
 If `@Traced` is specified at the class level, then `@Traced(false)` is used to annotate specific methods to disable creation of a Span for those methods.
 By default all JAX-RS endpoint methods are traced.
 To disable Span creation of a specific JAX-RS endpoint, the `@Traced(false)` annotation can be used.
 +
 When the `@Traced(false)` annotation is used for a JAX-RS endpoint method, the upstream SpanContext will not be extracted. Any Spans created, either automatically for outbound requests, or explicitly using an injected Tracer, will not have an upstream parent Span in the Span hierarchy.
 
-* operationName=<Name for the Span>.
-Default is "".
-If the `@Traced` annotation finds the operationName as "", the default operationName is used. For a JAX-RS endpoint method (see <<server-span-name>>).
+* `operationName=<Name for the Span>`.
+Default is `""`.
+If the `@Traced` annotation finds the operationName as `""`, the default operation name is used. For a JAX-RS endpoint method (see <<server-span-name>>).
 If the annotated method is not a JAX-RS endpoint, the default operation name of the new Span for the method is
 ```
 <package name>.<class name>.<method name>
@@ -210,9 +208,9 @@ public @interface Traced {
 }
 ----
 
-==== io.opentracing.Tracer access
+==== Access to the configured tracer
 
-This proposal also specifies that the underlying opentracing.io Tracer object
+This proposal also specifies that the underlying OpenTracing Tracer object
 configured instance is available for developer use. The MicroProfile
 implementation will make the configured Tracer available with CDI injection.
 
@@ -227,9 +225,7 @@ Example:
 io.opentracing.Tracer configuredTracer;
 ----
 
-Access to the configured Tracer gives full access to opentracing.io functions.
-
-The Tracer object enables support for the more complex tracing requirements, such as when a Span is started in one method, and finished in another.
+The Tracer object enables support for the more complex tracing requirements, such as creating spans inside business methods.
 
 Access to the Tracer also allows tags, logs and baggage to be added to Spans with, for example:
 [source,java]


### PR DESCRIPTION
Mostly minor typography fixes and some paragraph simplifications.

- use OpenTracing, OpenCensus
- comply with OpenTracing semantic conventions
- fix links
- move span extraction section to inbound requests
- use code style where it makes sense