### PR TITLE
Explicitly enable tracing for clients

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrar.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrar.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing;
+
+import java.util.ServiceLoader;
+import java.util.concurrent.ExecutorService;
+import javax.ws.rs.client.ClientBuilder;
+
+/**
+ * This class registers tracing components into {@link ClientBuilder}.
+ * It is required to call {@link #configure(ClientBuilder)} or its variants to enable tracing in
+ * {@link javax.ws.rs.client.Client}, however implementation might enable tracing globally.
+ *
+ * Invoking {@link ClientTracingRegistrar#configure(ClientBuilder)} returns
+ * a {@link ClientBuilder} with enabled tracing integration. Note that following calls to
+ * {@link ClientBuilder} which change {@link ExecutorService} might break tracing integration. If a custom
+ * {@link ExecutorService} has to be used use {@link ClientTracingRegistrar#configure(ClientBuilder, ExecutorService)}.
+ *
+ * @author Pavol Loffay
+ */
+public class ClientTracingRegistrar {
+
+    private ClientTracingRegistrar() {}
+
+    /**
+     *  Register tracing components into client builder instance.
+     *
+     * @param clientBuilder client builder
+     * @return clientBuilder with tracing integration
+     */
+    public static ClientBuilder configure(ClientBuilder clientBuilder) {
+        for(ClientTracingRegistrarProvider registrar: ServiceLoader.load(ClientTracingRegistrarProvider.class)) {
+            return registrar.configure(clientBuilder);
+        }
+        return clientBuilder;
+    }
+
+    /**
+     *  Register tracing components into client builder instance.
+     *
+     * @param clientBuilder client builder
+     * @param executorService executorService which will be added to the client. Note that this overrides
+     *      executor service added previously to the client.
+     * @return clientBuilder with tracing integration
+     */
+    public static ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService) {
+        for(ClientTracingRegistrarProvider registrar: ServiceLoader.load(ClientTracingRegistrarProvider.class)) {
+            return registrar.configure(clientBuilder, executorService);
+        }
+        return clientBuilder;
+    }
+}

--- a/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrarProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrarProvider.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing;
+
+import java.util.concurrent.ExecutorService;
+import javax.ws.rs.client.ClientBuilder;
+
+/**
+ * Implementation of this interface will be used to configure {@link ClientBuilder}
+ * when {@link ClientTracingRegistrar#configure(ClientBuilder)} is called.
+ *
+ * Implementation must be registered in
+ * <code>
+ * META-INF/services/org.eclipse.microprofile.opentracing.{@link ClientTracingRegistrarProvider}
+ * </code>
+ *
+ * @author Pavol Loffay
+ */
+public interface ClientTracingRegistrarProvider {
+
+    /**
+     * Configures {@link ClientBuilder} with tracing integration.
+     *
+     * @param clientBuilder Client builder to configure.
+     * @return clientBuilder with tracing integration
+     */
+    ClientBuilder configure(ClientBuilder clientBuilder);
+
+    /**
+     * Configures {@link ClientBuilder} with tracing integration.
+     *
+     * @param clientBuilder Client builder to configure.
+     * @param executorService Executor service which will be added to the client builder.
+     * @return clientBuilder with tracing integration
+     */
+    ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService);
+}

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -136,6 +136,7 @@ Spans created for incoming requests will have the following tags added by defaul
 * `Tags.HTTP_METHOD`
 * `Tags.HTTP_URL`
 * `Tags.HTTP_STATUS`
+* `Tags.COMPONENT = "jaxrs"`
 * `Tags.ERROR` (if true)
 
 `Tags.SPAN_KIND` MUST be specified at Span start time.
@@ -146,7 +147,7 @@ If there is an exception object available the implementation SHOULD also add log
 ==== Span creation and injection for outbound requests
 Tracing in `javax.ws.rs.Client` has to be explicitly enabled by invoking
 `org.eclipse.microprofile.opentracing.ClientTracingRegistrar.configure(ClientBuilder clientBuilder)`.
-Implementation might enable client tracing globally, then explicit configuration has no effect.
+The implementation might enable client tracing globally, in this case explicit configuration has no effect.
 
 When a request is sent from a JAX-RS `javax.ws.rs.client.Client`, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
 
@@ -163,6 +164,7 @@ Spans created for outgoing requests will have the following tags added by defaul
 * `Tags.HTTP_METHOD`
 * `Tags.HTTP_URL`
 * `Tags.HTTP_STATUS`
+* `Tags.COMPONENT = "jaxrs"`
 * `Tags.ERROR` (if true)
 
 `Tags.SPAN_KIND` MUST be specified at Span start time.

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -144,6 +144,10 @@ Spans created for incoming requests will have the following tags added by defaul
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 ==== Span creation and injection for outbound requests
+Tracing in `javax.ws.rs.Client` has to be explicitly enabled by invoking
+`org.eclipse.microprofile.opentracing.ClientTracingRegistrar.configure(ClientBuilder clientBuilder)`.
+Implementation might enable client tracing globally, then explicit configuration has no effect.
+
 When a request is sent from a JAX-RS `javax.ws.rs.client.Client`, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
 
 ===== Client Span name

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
@@ -75,6 +75,7 @@ import io.opentracing.tag.Tags;
  * @author <a href="mailto:steve.m.fontes@gmail.com">Steve Fontes</a>
  */
 public class OpentracingClientTests extends Arquillian {
+    private static final String JAXRS_COMPONENT = "jaxrs";
 
     /** Server app URL for the client tests. */
     @ArquillianResource
@@ -144,7 +145,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_SIMPLE_TEST,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 )
@@ -181,7 +183,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_ANNOTATIONS,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 ),
@@ -273,7 +276,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_OPERATION_NAME,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 )
@@ -305,7 +309,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServicesWithOperationName.REST_TEST_SERVICE_PATH_WITH_OP_NAME,
                         TestServerWebServicesWithOperationName.REST_OPERATION_CLASS_OP_NAME,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 ),
@@ -351,7 +356,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServicesWithOperationName.REST_TEST_SERVICE_PATH_WITH_OP_NAME,
                         TestServerWebServicesWithOperationName.REST_OPERATION_CLASS_AND_METHOD_OP_NAME,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 )
@@ -435,7 +441,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_ANNOTATION_EXCEPTION,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 ),
@@ -464,7 +471,8 @@ public class OpentracingClientTests extends Arquillian {
             TestServerWebServices.REST_TEST_SERVICE_PATH,
             service,
             null,
-            Status.INTERNAL_SERVER_ERROR.getStatusCode()
+            Status.INTERNAL_SERVER_ERROR.getStatusCode(),
+            JAXRS_COMPONENT
         );
 
         return expectedTags;
@@ -756,7 +764,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_LOCAL_SPAN,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 ),
@@ -797,7 +806,8 @@ public class OpentracingClientTests extends Arquillian {
                         TestServerWebServices.REST_TEST_SERVICE_PATH,
                         TestServerWebServices.REST_ASYNC_LOCAL_SPAN,
                         null,
-                        Status.OK.getStatusCode()
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
                     ),
                     Collections.emptyList()
                 ),
@@ -859,7 +869,8 @@ public class OpentracingClientTests extends Arquillian {
                 TestServerWebServices.REST_TEST_SERVICE_PATH,
                 TestServerWebServices.REST_NESTED,
                 queryParameters,
-                Status.OK.getStatusCode()
+                Status.OK.getStatusCode(),
+                JAXRS_COMPONENT
             );
         }
 
@@ -887,6 +898,7 @@ public class OpentracingClientTests extends Arquillian {
                         && !key.equals(Tags.HTTP_METHOD.getKey())
                         && !key.equals(Tags.HTTP_URL.getKey())
                         && !key.equals(Tags.HTTP_STATUS.getKey())
+                        && !key.equals(Tags.COMPONENT.getKey())
                         && !key.equals(TestServerWebServices.LOCAL_SPAN_TAG_KEY)));
 
         // It's okay if the returnedTree has log entries other than the ones we
@@ -909,7 +921,7 @@ public class OpentracingClientTests extends Arquillian {
      */
     private Map<String, Object> getExpectedSpanTags(String spanKind,
             String httpMethod, String service, String relativePath,
-            Map<String, Object> queryParameters, int httpStatus) {
+            Map<String, Object> queryParameters, int httpStatus, String component) {
 
         // When adding items to this, also add to assertEqualTrees
 
@@ -918,6 +930,7 @@ public class OpentracingClientTests extends Arquillian {
         tags.put(Tags.HTTP_METHOD.getKey(), httpMethod);
         tags.put(Tags.HTTP_URL.getKey(), getWebServiceURL(service, relativePath, queryParameters));
         tags.put(Tags.HTTP_STATUS.getKey(), httpStatus);
+        tags.put(Tags.COMPONENT.getKey(), component);
         return tags;
     }
 

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -42,6 +42,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 
+import org.eclipse.microprofile.opentracing.ClientTracingRegistrar;
 import org.eclipse.microprofile.opentracing.Traced;
 
 import io.opentracing.Span;
@@ -367,7 +368,7 @@ public class TestServerWebServices {
      * @param requestUrl The request URL.
      */
     private void executeNested(String requestUrl) {
-        Client restClient = ClientBuilder.newBuilder().build();
+        Client restClient = ClientTracingRegistrar.configure(ClientBuilder.newBuilder()).build();
         WebTarget target = restClient.target(requestUrl);
         Response nestedResponse = target.request().get();
         nestedResponse.close();
@@ -379,7 +380,7 @@ public class TestServerWebServices {
      * @return Future for the Response.
      */
     private Future<Response> executeNestedAsync(String requestUrl) {
-        Client restClient = ClientBuilder.newBuilder().build();
+        Client restClient = ClientTracingRegistrar.configure(ClientBuilder.newBuilder()).build();
         WebTarget target = restClient.target(requestUrl);
         return target.request().async().get();
     }


### PR DESCRIPTION
Resolves #14 

This does not require client tracing globally enabled. Whether it's client tracing globally enabled is optional - depends on the implementation. Client tracing can be explicitly enabled by `client = ClientTracingRegistrar.configure(builder)` , when it's globally enabled it's noop.

It's WIP: it needs more documentation work.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>