### PR TITLE
Remove trailing spaces from sources

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/opentracing/Traced.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/Traced.java
@@ -34,16 +34,16 @@ import static java.lang.annotation.RetentionPolicy.RUNTIME;
  * This annotation allows fine-tuned control over which classes and methods
  * create OpenTracing spans. By default, all JAX-RS methods implicitly have
  * this annotation.
- * 
+ *
  * This annotation applies to a class or a method. When applied to a class, this
  * annotation is applied to all methods of the class. If the annotation is
  * applied to a class and method then the annotation applied to the method takes
  * precedence. The annotation starts a Span at the beginning of the method, and
  * finishes the Span at the end of the method.
- * 
+ *
  * This annotation also has {@code InterceptorBinding} for frameworks to
  * process all of each application's explicit {@code Traced} annotations.
- * 
+ *
  * @author <a href="mailto:steve.m.fontes@gmail.com">Steve Fontes</a>
  */
 @Documented
@@ -57,13 +57,13 @@ public @interface Traced {
      * methods to disable creation of a Span for those methods. By default all
      * JAX-RS endpoint methods are traced. To disable Span creation of a
      * specific JAX-RS endpoint, the @Traced(false) annotation can be used.
-     * 
+     *
      * When the <code>@Traced(false)</code> annotation is used for a JAX-RS
      * endpoint method, the upstream SpanContext will not be extracted. Any
      * Spans created, either automatically for outbound requests, or explicitly
      * using an injected Tracer, will not have an upstream parent Span in the
      * Span hierarchy.
-     * 
+     *
      * @return whether this method should be traced.
      */
     @Nonbinding
@@ -80,7 +80,7 @@ public @interface Traced {
      * operationName is specified on a class, that operationName will be used
      * for all methods of the class unless a method explicitly overrides it with
      * its own operationName.
-     * 
+     *
      * @return the name to give the Span for this trace point.
      */
     @Nonbinding

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
@@ -75,7 +75,7 @@ import io.opentracing.tag.Tags;
  * @author <a href="mailto:steve.m.fontes@gmail.com">Steve Fontes</a>
  */
 public class OpentracingClientTests extends Arquillian {
-    
+
     /** Server app URL for the client tests. */
     @ArquillianResource
     private URL deploymentURL;
@@ -101,10 +101,10 @@ public class OpentracingClientTests extends Arquillian {
 
         return war;
     }
-   
+
     /**
      * Before each test method, clear the tracer.
-     * 
+     *
      * In the case that a test fails, other tests may still run, and if the
      * clearTracer call is done at the end of a test, then the next test may
      * still have old spans in its result, which would both fail that test
@@ -246,7 +246,7 @@ public class OpentracingClientTests extends Arquillian {
         TestSpanTree spans = executeRemoteWebServiceTracerTree();
 
         TestSpanTree expectedTree = new TestSpanTree();
-        
+
         assertEqualTrees(spans, expectedTree);
     }
 
@@ -388,9 +388,9 @@ public class OpentracingClientTests extends Arquillian {
         response.close();
 
         TestSpanTree spans = executeRemoteWebServiceTracerTree();
-        
+
         Map<String, Object> expectedTags = getExpectedSpanTagsForError(service, Tags.SPAN_KIND_SERVER);
-        
+
         TestSpanTree expectedTree = new TestSpanTree(
             new TreeNode<>(
                 new TestSpan(
@@ -419,7 +419,7 @@ public class OpentracingClientTests extends Arquillian {
         response.close();
 
         TestSpanTree spans = executeRemoteWebServiceTracerTree();
-        
+
         TestSpanTree expectedTree = new TestSpanTree(
             new TreeNode<>(
                 new TestSpan(
@@ -466,7 +466,7 @@ public class OpentracingClientTests extends Arquillian {
             null,
             Status.INTERNAL_SERVER_ERROR.getStatusCode()
         );
-        
+
         return expectedTags;
     }
 
@@ -476,29 +476,29 @@ public class OpentracingClientTests extends Arquillian {
     @Test
     @RunAsClient
     private void testNestedSpans() throws InterruptedException {
-        
+
         int nestDepth = 1;
         int nestBreadth = 2;
         int uniqueId = getRandomNumber();
         boolean failNest = false;
         boolean async = false;
-        
+
         executeNestedSpans(nestDepth, nestBreadth, uniqueId, failNest, async);
     }
-    
+
     /**
      * Test a web service call that makes nested calls with a client failure.
      */
     @Test
     @RunAsClient
     private void testNestedSpansWithClientFailure() throws InterruptedException {
-        
+
         int nestDepth = 1;
         int nestBreadth = 2;
         int uniqueId = getRandomNumber();
         boolean failNest = true;
         boolean async = false;
-        
+
         executeNestedSpans(nestDepth, nestBreadth, uniqueId, failNest, async);
     }
 
@@ -513,13 +513,13 @@ public class OpentracingClientTests extends Arquillian {
     private void executeNestedSpans(int nestDepth, int nestBreadth,
             int uniqueId, boolean failNest, boolean async) {
         executeNested(uniqueId, nestDepth, nestBreadth, failNest, async);
-        
+
         TestSpanTree spans = executeRemoteWebServiceTracerTree();
         TestSpanTree expectedTree = new TestSpanTree(createExpectedNestTree(uniqueId, nestBreadth, failNest, async));
-        
+
         assertEqualTrees(spans, expectedTree);
     }
-    
+
     /**
      * Test the nested web service concurrently. A unique ID is generated
      * in the URL of each request and propagated down the nested spans.
@@ -536,7 +536,7 @@ public class OpentracingClientTests extends Arquillian {
         int nestBreadth = 2;
         boolean failNest = false;
         boolean async = false;
-        
+
         runNestedTests(numberOfCalls, nestDepth, nestBreadth, failNest, async);
     }
 
@@ -553,7 +553,7 @@ public class OpentracingClientTests extends Arquillian {
         int nestBreadth = 2;
         boolean failNest = false;
         boolean async = true;
-        
+
         runNestedTests(numberOfCalls, nestDepth, nestBreadth, failNest, async);
     }
 
@@ -602,20 +602,20 @@ public class OpentracingClientTests extends Arquillian {
         for (Future<?> future: futures) {
             future.get();
         }
-        
+
         executorService.awaitTermination(1, TimeUnit.SECONDS);
         executorService.shutdown();
-        
+
         TestSpanTree spans = executeRemoteWebServiceTracerTree();
-        
+
         List<TreeNode<TestSpan>> rootSpans = spans.getRootSpans();
 
         // If this assertion fails, it means that the number of returned
         // root spans doesn't equal the number of web service calls.
         Assert.assertEquals(rootSpans.size(), numberOfCalls);
-        
+
         for (TreeNode<TestSpan> rootSpan: rootSpans) {
-            
+
             // Extract the unique ID from the root span's URL:
             String url = (String) rootSpan.getData().getTags().get(Tags.HTTP_URL.getKey());
             int i = url.indexOf(TestServerWebServices.PARAM_UNIQUE_ID);
@@ -626,18 +626,18 @@ public class OpentracingClientTests extends Arquillian {
                 uniqueIdStr = uniqueIdStr.substring(0, i);
             }
             int uniqueId = Integer.parseInt(uniqueIdStr);
-            
+
             // If this assertion fails, it means that the unique ID
             // in the root span URL doesn't match any of the
             // unique IDs that we sent in the requests above.
             boolean removeResult = uniqueIds.remove(uniqueId);
-            
+
             if (!removeResult) {
                 debug("Unique ID " + uniqueId + " not found in request list. Span: " + rootSpan);
             }
-            
+
             Assert.assertTrue(removeResult);
-            
+
             TreeNode<TestSpan> expectedTree = createExpectedNestTree(uniqueId, nestBreadth, failNest, async);
             assertEqualTrees(rootSpan, expectedTree);
         }
@@ -680,7 +680,7 @@ public class OpentracingClientTests extends Arquillian {
     private void executeNested(int uniqueId, int nestDepth, int nestBreadth, boolean failNest, boolean async) {
         Map<String, Object> queryParameters = getNestedQueryParameters(uniqueId,
                 nestDepth, nestBreadth, failNest, async);
-        
+
         Response response = executeRemoteWebServiceRaw(
             TestServerWebServices.REST_TEST_SERVICE_PATH,
             TestServerWebServices.REST_NESTED,
@@ -703,7 +703,7 @@ public class OpentracingClientTests extends Arquillian {
     private Future<Response> executeNestedAsync(int uniqueId, int nestDepth, int nestBreadth, boolean failNest, boolean async) {
         Map<String, Object> queryParameters = getNestedQueryParameters(uniqueId,
                 nestDepth, nestBreadth, failNest, async);
-        
+
         return executeRemoteWebServiceRawAsync(
             TestServerWebServices.REST_TEST_SERVICE_PATH,
             TestServerWebServices.REST_NESTED,
@@ -711,7 +711,7 @@ public class OpentracingClientTests extends Arquillian {
             Status.OK
         );
     }
-    
+
     /**
      * @param uniqueId Some unique ID.
      * @param nestDepth How deep to nest the calls.
@@ -829,7 +829,7 @@ public class OpentracingClientTests extends Arquillian {
             boolean isFailed, boolean async) {
         String operationName;
         Map<String, Object> expectedTags;
-        
+
         if (isFailed) {
             operationName = getOperationName(
                 spanKind,
@@ -862,7 +862,7 @@ public class OpentracingClientTests extends Arquillian {
                 Status.OK.getStatusCode()
             );
         }
-        
+
         return new TestSpan(
             operationName,
             expectedTags,
@@ -873,13 +873,13 @@ public class OpentracingClientTests extends Arquillian {
     /**
      * This wrapper method allows for potential post-processing, such as
      * removing tags that we don't care to compare in {@code returnedTree}.
-     * 
+     *
      * @param returnedTree The returned tree from the web service.
      * @param expectedTree The simulated tree that we expect.
      */
     private void assertEqualTrees(ConsumableTree<TestSpan> returnedTree,
             ConsumableTree<TestSpan> expectedTree) {
-        
+
         // It's okay if the returnedTree has tags other than the ones we
         // want to compare, so just remove those
         returnedTree.visitTree(span -> span.getTags().keySet()
@@ -888,12 +888,12 @@ public class OpentracingClientTests extends Arquillian {
                         && !key.equals(Tags.HTTP_URL.getKey())
                         && !key.equals(Tags.HTTP_STATUS.getKey())
                         && !key.equals(TestServerWebServices.LOCAL_SPAN_TAG_KEY)));
-        
+
         // It's okay if the returnedTree has log entries other than the ones we
         // want to compare, so just remove those
         returnedTree.visitTree(span -> span.getLogEntries()
                 .removeIf(logEntry -> true));
-        
+
         Assert.assertEquals(returnedTree, expectedTree);
     }
 
@@ -910,9 +910,9 @@ public class OpentracingClientTests extends Arquillian {
     private Map<String, Object> getExpectedSpanTags(String spanKind,
             String httpMethod, String service, String relativePath,
             Map<String, Object> queryParameters, int httpStatus) {
-        
+
         // When adding items to this, also add to assertEqualTrees
-        
+
         Map<String, Object> tags = new HashMap<>();
         tags.put(Tags.SPAN_KIND.getKey(), spanKind);
         tags.put(Tags.HTTP_METHOD.getKey(), httpMethod);
@@ -928,12 +928,12 @@ public class OpentracingClientTests extends Arquillian {
     private Map<String, Object> getExpectedLocalSpanTags() {
 
         // When adding items to this, also add to assertEqualTrees
-        
+
         Map<String, Object> tags = new HashMap<>();
         tags.put(TestServerWebServices.LOCAL_SPAN_TAG_KEY, TestServerWebServices.LOCAL_SPAN_TAG_VALUE);
         return tags;
     }
-    
+
     /**
      * Create web service URL.
      * @param service Web service path
@@ -943,7 +943,7 @@ public class OpentracingClientTests extends Arquillian {
     private String getWebServiceURL(final String service, final String relativePath) {
         return getWebServiceURL(service, relativePath, null);
     }
-    
+
     /**
      * Create web service URL.
      * @param service Web service path
@@ -969,7 +969,7 @@ public class OpentracingClientTests extends Arquillian {
     private Response executeRemoteWebServiceRaw(final String service, final String relativePath, Status expectedStatus) {
         return executeRemoteWebServiceRaw(service, relativePath, null, expectedStatus);
     }
-    
+
     /**
      * Execute a remote web service and return the content.
      * @param service Web service path
@@ -982,9 +982,9 @@ public class OpentracingClientTests extends Arquillian {
             Map<String, Object> queryParameters, Status expectedStatus) {
         Client client = ClientBuilder.newClient();
         String url = getWebServiceURL(service, relativePath, queryParameters);
-        
+
         debug("Executing " + url);
-        
+
         WebTarget target = client.target(url);
         Response response = target.request().get();
         if (response.getStatus() != expectedStatus.getStatusCode()) {
@@ -1006,7 +1006,7 @@ public class OpentracingClientTests extends Arquillian {
             Response response) {
         Assert.assertEquals(response.getStatus(), expectedStatus.getStatusCode());
     }
-    
+
     /**
      * Execute a remote web service asynchronously and return a wrapper around a Future to the Response
      * @param service Web service path
@@ -1019,9 +1019,9 @@ public class OpentracingClientTests extends Arquillian {
             Map<String, Object> queryParameters, Status expectedStatus) {
         Client client = ClientBuilder.newClient();
         String url = getWebServiceURL(service, relativePath, queryParameters);
-        
+
         debug("Executing " + url);
-        
+
         WebTarget target = client.target(url);
         return target.request().async().get();
     }
@@ -1042,12 +1042,12 @@ public class OpentracingClientTests extends Arquillian {
      */
     private TestSpanTree executeRemoteWebServiceTracerTree() {
         TestSpanTree result = executeRemoteWebServiceTracer().spanTree();
-        
+
         debug("Tracer returned " + result);
-        
+
         return result;
     }
-    
+
     /**
      * Get operation name depending on the {@code spanKind}.
      * @param spanKind The type of span.
@@ -1077,7 +1077,7 @@ public class OpentracingClientTests extends Arquillian {
         Response delete = client.target(url).request().delete();
         delete.close();
     }
-    
+
     /**
      * Print debug message to target/surefire-reports/testng-results.xml.
      * @param message The debug message.

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedClassWithOperationName.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedClassWithOperationName.java
@@ -29,7 +29,7 @@ import org.eclipse.microprofile.opentracing.Traced;
 @ApplicationScoped
 @Traced(operationName = TestAnnotatedClassWithOperationName.OPERATION_NAME)
 public class TestAnnotatedClassWithOperationName {
-    
+
     /**
      * Operation name for this class.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedMethods.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedMethods.java
@@ -28,7 +28,7 @@ import org.eclipse.microprofile.opentracing.Traced;
  */
 @ApplicationScoped
 public class TestAnnotatedMethods {
-    
+
     /**
      * Method that we expect to be Traced.
      */
@@ -36,7 +36,7 @@ public class TestAnnotatedMethods {
     public void annotatedMethodExplicitlyTraced() {
         System.out.println("Called annotatedMethodExplicitlyTraced");
     }
-    
+
     /**
      * Method that we expect to not be Traced.
      */

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -58,37 +58,37 @@ public class TestServerWebServices {
      * The path to this set of web services.
      */
     public static final String REST_TEST_SERVICE_PATH = "testServices";
-    
+
     /**
      * Web service endpoint for the simpleTest call.
      */
     public static final String REST_SIMPLE_TEST = "simpleTest";
-    
+
     /**
      * Web service endpoint that creates local span.
      */
     public static final String REST_LOCAL_SPAN = "localSpan";
-    
+
     /**
      * Async web service endpoint that creates local span.
      */
     public static final String REST_ASYNC_LOCAL_SPAN = "asyncLocalSpan";
-    
+
     /**
      * Web service endpoint that will return HTTP 500.
      */
     public static final String REST_ERROR = "error";
-    
+
     /**
      * Web service that throws an unhandled exception and return HTTP 500.
      */
     public static final String REST_EXCEPTION = "exception";
-    
+
     /**
      * Web service endpoint to test Traced annotations.
      */
     public static final String REST_ANNOTATIONS = "annotations";
-    
+
     /**
      * Web service endpoint to test a Traced annotation with an exception.
      */
@@ -113,12 +113,12 @@ public class TestServerWebServices {
      * Web service endpoint that will call itself some number of times.
      */
     public static final String REST_NESTED = "nested";
-    
+
     /**
      * Query parameter for the number of nested calls.
      */
     public static final String PARAM_NEST_DEPTH = "nestDepth";
-    
+
     /**
      * Query parameter for the breadth of nesting.
      */
@@ -149,26 +149,26 @@ public class TestServerWebServices {
      */
     @Inject
     private Tracer tracer;
-    
+
     /**
      * Represents the URI of the executing web service call.
      */
     @Context
     private UriInfo uri;
-    
+
     /**
      * Injected class with Traced annotation on the class.
      */
     @Inject
     private TestAnnotatedClass testAnnotatedClass;
-    
+
     /**
      * Injected class with Traced annotation disable on the class,
      * but enabled on methods.
      */
     @Inject
     private TestDisabledAnnotatedClass testDisabledAnnotatedClass;
-    
+
     /**
      * Injected class with Traced annotation on methods.
      */
@@ -270,7 +270,7 @@ public class TestServerWebServices {
         }
         return Response.ok().build();
     }
-    
+
     /**
      * Shouldn't create a span.
      * @return OK response
@@ -282,7 +282,7 @@ public class TestServerWebServices {
     public Response notTraced() {
         return Response.ok().build();
     }
-    
+
     /**
      * Traced with an explicit operation name.
      * @return OK response
@@ -302,7 +302,7 @@ public class TestServerWebServices {
      *
      * A nesting depth greater than zero causes a call to the nesting service
      * with the depth reduced by one (1).
-     * 
+     *
      * The {@code nestBreadth} controls how many concurrent, nested calls are
      * made on the first level of nesting.
      *
@@ -324,7 +324,7 @@ public class TestServerWebServices {
             @QueryParam(PARAM_FAIL_NEST) boolean failNest,
             @QueryParam(PARAM_ASYNC) boolean async)
             throws InterruptedException, ExecutionException {
-        
+
         if (nestDepth > 0) {
             Map<String, Object> nestParameters = new HashMap<String, Object>();
 
@@ -340,12 +340,12 @@ public class TestServerWebServices {
                 nestParameters.put(PARAM_FAIL_NEST, false);
                 nestParameters.put(PARAM_ASYNC, false);
             }
-            
+
             String requestUrl = getRequestPath(
                     REST_TEST_SERVICE_PATH, target, nestParameters);
-            
+
             List<Future<Response>> futures = new ArrayList<>();
-            
+
             for (int i = 0; i < nestBreadth; i++) {
                 if (async) {
                     futures.add(executeNestedAsync(requestUrl));
@@ -354,7 +354,7 @@ public class TestServerWebServices {
                     executeNested(requestUrl);
                 }
             }
-            
+
             for (Future<Response> future : futures) {
                 future.get().close();
             }
@@ -395,7 +395,7 @@ public class TestServerWebServices {
     public String getRequestPath(
             String servicePath, String endpointPath,
             Map<String, Object> requestParameters) {
-        
+
         String incomingUrl = uri.getAbsolutePath().toString();
         int i = incomingUrl.indexOf(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT);
         if (i == -1) {
@@ -418,7 +418,7 @@ public class TestServerWebServices {
 
         return result;
     }
-    
+
     /**
      * Potentially print a debug message.
      * @param message Debug message.
@@ -433,7 +433,7 @@ public class TestServerWebServices {
      *
      * The child span must be finished using {@link #finishChildSpan} before
      * completing the service request which created the span.
-     * 
+     *
      * If there is no active span, the newly created span is made the active
      * span.
      *

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServicesWithOperationName.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServicesWithOperationName.java
@@ -38,7 +38,7 @@ public class TestServerWebServicesWithOperationName {
      * The path to this set of web services.
      */
     public static final String REST_TEST_SERVICE_PATH_WITH_OP_NAME = "testServicesWithOpName";
-    
+
     /**
      * Traced operationName prefix.
      */
@@ -53,7 +53,7 @@ public class TestServerWebServicesWithOperationName {
      * Web service endpoint with an explicit operation name on the class and endpoint.
      */
     public static final String REST_OPERATION_CLASS_AND_METHOD_OP_NAME = "classAndMethodOperationName";
-    
+
     /**
      * Explicit endpoint operation name.
      */
@@ -67,7 +67,7 @@ public class TestServerWebServicesWithOperationName {
 
     /**
      * Test class with Traced annotation and operation name.
-     * 
+     *
      * @return OK response
      */
     @GET
@@ -81,7 +81,7 @@ public class TestServerWebServicesWithOperationName {
 
     /**
      * Test class and endpoint with Traced annotation and operation name.
-     * 
+     *
      * @return OK response
      */
     @Traced(operationName = ENDPOINT_OPERATION_NAME)

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -43,7 +43,7 @@ public class TestWebServicesApplication extends Application {
      * The context root of JAXRS web services.
      */
     public static final String TEST_WEB_SERVICES_CONTEXT_ROOT = "rest";
-    
+
     /**
      * {@inheritDoc}
      */
@@ -82,28 +82,28 @@ public class TestWebServicesApplication extends Application {
      */
     public static String getQueryString(Map<String, Object> queryParameters) {
         String result = "?";
-    
+
         String prefix = null;
         for (Map.Entry<String, Object> parmEntry : queryParameters
                 .entrySet()) {
             String parmName = parmEntry.getKey();
             Object parmValue = parmEntry.getValue();
-    
+
             if (prefix != null) {
                 result += prefix;
             }
             else {
                 prefix = "&";
             }
-    
+
             result += urlEncode(parmName);
-    
+
             if (parmValue != null) {
                 result += "=";
                 result += urlEncode(parmValue.toString());
             }
         }
-        
+
         return result;
     }
 
@@ -120,7 +120,7 @@ public class TestWebServicesApplication extends Application {
             throw new RuntimeException(e);
         }
     }
-    
+
     /**
      * Create an example RuntimeException used by a web service.
      * @return New RuntimeException.

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpan.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpan.java
@@ -67,7 +67,7 @@ public class TestSpan implements Span {
      * Tags.
      */
     private Map<String, Object> tags = new HashMap<>();
-    
+
     /**
      * Log entries.
      */
@@ -355,13 +355,13 @@ public class TestSpan implements Span {
     public String toString() {
         // Only print the parts that are checked in equals so that an
         // assertion failure is easy to understand.
-        
+
         // return "{ " + "startMicros: " + startMicros
         //         + ", finishMicros: " + finishMicros + ", traceId: "
         //         + traceId + ", parentId: " + parentId + ", spanId: "
         //         + spanId + ", operationName: " + cachedOperationName
         //         + ", tags: " + tags + " }";
-        
+
         // Sort the tags to make it easier to visually compare object outputs.
         List<Entry<String, Object>> tagsList = new ArrayList<>();
         tagsList.addAll(tags.entrySet());
@@ -372,7 +372,7 @@ public class TestSpan implements Span {
                 return x.getKey().compareTo(y.getKey());
             }
         });
-        
+
         return "{ " + "operationName: " + cachedOperationName + ", tags: "
                 + tagsList + ", logEntries: " + logEntries + "}";
     }
@@ -390,7 +390,7 @@ public class TestSpan implements Span {
                         + otherSpan.cachedOperationName);
                 return false;
             }
-            
+
             if (tags.size() != otherSpan.tags.size()) {
                 System.err.println("MISMATCH: Number of tags doesn't match");
                 return false;
@@ -399,7 +399,7 @@ public class TestSpan implements Span {
             if (!tags.equals(otherSpan.tags)) {
                 return false;
             }
-            
+
             if (logEntries.size() != otherSpan.logEntries.size()) {
                 System.err.println(
                         "MISMATCH: Number of log entries doesn't match ("
@@ -407,11 +407,11 @@ public class TestSpan implements Span {
                                 + otherSpan.logEntries.size() + ")");
                 return false;
             }
-            
+
             for (int i = 0; i < logEntries.size(); i++) {
                 Map<String, ?> logEntryX = logEntries.get(i);
                 Map<String, ?> logEntryY = otherSpan.logEntries.get(i);
-                
+
                 if (!logEntryX.equals(logEntryY)) {
                     return false;
                 }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpanTree.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/tracer/TestSpanTree.java
@@ -62,7 +62,7 @@ public class TestSpanTree implements ConsumableTree<TestSpan> {
             rootSpans.add(rootSpan);
         }
     }
-    
+
     /**
      * Return a list of this tree's root spans.
      * @return List of root spans.
@@ -234,7 +234,7 @@ public class TestSpanTree implements ConsumableTree<TestSpan> {
                 child.visitTree(visitor);
             }
         }
-        
+
         /**
          * {@inheritDoc}
          */


### PR DESCRIPTION
Just a cosmetical change to keep the sources clean.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>