### PR TITLE
Do not use activeSpan/scope for manually passed span

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -446,10 +446,7 @@ public class TestServerWebServices {
         if (activeSpan != null) {
             spanBuilder.asChildOf(activeSpan.context());
         }
-        Span childSpan = spanBuilder.startManual();
-        if (activeSpan == null) {
-            tracer.scopeManager().activate(childSpan, true);
-        }
+        Span childSpan = spanBuilder.start();
         childSpan.setTag(LOCAL_SPAN_TAG_KEY, LOCAL_SPAN_TAG_VALUE);
         return childSpan;
     }


### PR DESCRIPTION
* This span is manually passed around, therefore scope is
not necessary and creates a leak.
* Also use .start instead of deprecated startManual

Signed-off-by: Pavol Loffay <ploffay@redhat.com>