### PR TITLE
Add changelog to specification

### DIFF
--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -256,5 +256,5 @@ This feature allows the decision to be made at the operational environment level
 
 * Added `ClientTracingRegistar` and `ClientTracingRegistarProvider`
 * Tracing in a JAX-RS client has to be explictly enabled
-* Depend upon 0.31 of opentracing.io API
+* Updated opentracing.io API from 0.30 to 0.31. This is a breaking change.
 

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -249,3 +249,12 @@ A configured Tracer object can be accessed with CDI injection.
 
 Current mechanisms require a decision at development time about the distributed trace system that will be used.
 This feature allows the decision to be made at the operational environment level.
+
+== Changelog
+
+=== Changes since 1.0
+
+* Added `ClientTracingRegistar` and `ClientTracingRegistarProvider`
+* Tracing in a JAX-RS client has to be explictly enabled
+* Depend upon 0.31 of opentracing.io API
+


### PR DESCRIPTION
This is to try to make it clear as to what has changed between releases rather than require someone to use try to work it out using git. The opentracing.io update is particularly important here as it not mentioned in the specification that there are any changes in how it works when it is in fact a breaking change.