### PR TITLE
Instrument mp-rest-client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <autorelease>false</autorelease>
 
         <version.mp.config>1.3</version.mp.config>
-        <version.mp.rest.client>1.1</version.mp.rest.client>
+        <version.mp.rest.client>1.2-m1</version.mp.rest.client>
         <!-- Versions of API dependencies -->
         <osgi-annotation.version>1.0.0</osgi-annotation.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         <autorelease>false</autorelease>
 
         <version.mp.config>1.3</version.mp.config>
-        <version.mp.rest.client>1.2-m1</version.mp.rest.client>
+        <version.mp.rest.client>1.2-m2</version.mp.rest.client>
         <!-- Versions of API dependencies -->
         <osgi-annotation.version>1.0.0</osgi-annotation.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,7 @@
         <autorelease>false</autorelease>
 
         <version.mp.config>1.3</version.mp.config>
+        <version.mp.rest.client>1.1</version.mp.rest.client>
         <!-- Versions of API dependencies -->
         <osgi-annotation.version>1.0.0</osgi-annotation.version>
 

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -168,8 +168,9 @@ Tracing in `javax.ws.rs.client.Client` has to be explicitly enabled by invoking
 The implementation might enable client tracing globally, in this case explicit configuration has no effect.
 
 ===== MicroProfile Rest Client
-Tracing for MicroProfile Rest Client is by default globally enabled and can be disabled by
-specifying `@Traced(false)` on the client interface or method.
+Tracing for MicroProfile Rest Client is by default globally enabled and it can be disabled by
+specifying `@Traced(false)` on the client interface or method. When it is specified on the client's
+interface tracing is disabled for all methods.
 
 ===== Client Span name
 The default operation name of the new Span for the outgoing request is

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -158,14 +158,18 @@ If there is an exception object available the implementation SHOULD also add log
 ==== Span creation and injection for outbound requests
 Tracing of client requests is support for `javax.ws.rs.client.Client` and MicroProfile Rest Client.
 
+When a request is sent from a traced client, a new Span is created and its SpanContext is injected
+in the outbound request for propagation downstream. The new Span will be a child of the active Span
+if an active Span exists. The new Span will be finished when the outbound request is completed.
+
+===== JAX-RS Client
 Tracing in `javax.ws.rs.client.Client` has to be explicitly enabled by invoking
 `org.eclipse.microprofile.opentracing.ClientTracingRegistrar.configure(ClientBuilder clientBuilder)`.
 The implementation might enable client tracing globally, in this case explicit configuration has no effect.
 
+===== MicroProfile Rest Client
 Tracing for MicroProfile Rest Client is by default globally enabled and can be disabled by
-specifying `@Traced(false)` on the client interface.
-
-When a request is sent from a traced client, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
+specifying `@Traced(false)` on the client interface or method.
 
 ===== Client Span name
 The default operation name of the new Span for the outgoing request is

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -156,7 +156,7 @@ Spans created for incoming requests will have the following tags added by defaul
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 ==== Span creation and injection for outbound requests
-Tracing of client requests is support for `javax.ws.rs.client.Client` and MicroProfile Rest Client.
+Tracing of client requests is supported for `javax.ws.rs.client.Client` and MicroProfile Rest Client.
 
 When a request is sent from a traced client, a new Span is created and its SpanContext is injected
 in the outbound request for propagation downstream. The new Span will be a child of the active Span

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -156,11 +156,16 @@ Spans created for incoming requests will have the following tags added by defaul
 If there is an exception object available the implementation SHOULD also add logs `event=error` and `error.object=<error object instance>` to the active span.
 
 ==== Span creation and injection for outbound requests
+Tracing of client requests is support for `javax.ws.rs.client.Client` and MicroProfile Rest Client.
+
 Tracing in `javax.ws.rs.client.Client` has to be explicitly enabled by invoking
 `org.eclipse.microprofile.opentracing.ClientTracingRegistrar.configure(ClientBuilder clientBuilder)`.
 The implementation might enable client tracing globally, in this case explicit configuration has no effect.
 
-When a request is sent from a JAX-RS `javax.ws.rs.client.Client`, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
+Tracing for MicroProfile Rest Client is by default globally enabled and can be disabled by
+specifying `@Traced(false)` on the client interface.
+
+When a request is sent from a traced client, a new Span is created and its SpanContext is injected in the outbound request for propagation downstream. The new Span will be a child of the active Span if an active Span exists. The new Span will be finished when the outbound request is completed.
 
 ===== Client Span name
 The default operation name of the new Span for the outgoing request is

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -58,6 +58,12 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.microprofile.rest.client</groupId>
+            <artifactId>microprofile-rest-client-api</artifactId>
+            <version>${version.mp.rest.client}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <scope>provided</scope>

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -511,9 +511,9 @@ public abstract class OpenTracingBaseTests extends Arquillian {
         for (int i = 0; i < nestBreadth; i++) {
             children[i] =
                 new TreeNode<>(
-                    getExpectedNestedServerSpan(path, Tags.SPAN_KIND_CLIENT, uniqueId, 0, 1, false, failNest, false),
+                    getExpectedNestedServerSpan(path, Tags.SPAN_KIND_CLIENT, uniqueId, 0, 1, false, failNest, async),
                     new TreeNode<>(
-                        getExpectedNestedServerSpan(path, Tags.SPAN_KIND_SERVER, uniqueId, 0, 1, false, failNest, false)
+                        getExpectedNestedServerSpan(path, Tags.SPAN_KIND_SERVER, uniqueId, 0, 1, false, failNest, async)
                     )
                 );
         }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
@@ -74,10 +74,9 @@ public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
      * @throws InterruptedException Problem executing web service.
      * @throws ExecutionException Thread pool problem.
      *
-     * TODO smallrye does not support async spec yet!
      */
-//    @Test
-//    @RunAsClient
+    @Test
+    @RunAsClient
     private void testMultithreadedNestedSpans() throws ExecutionException, InterruptedException {
         int numberOfCalls = 100;
         int nestDepth = 1;
@@ -93,7 +92,7 @@ public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
      * @throws InterruptedException Problem executing web service.
      * @throws ExecutionException Thread pool problem.
      *
-     * TODO smallrye does not support async spec yet!
+     * TODO smallrye does not support async spec (1.1) yet https://github.com/smallrye/smallrye-rest-client/issues/6
      */
 //    @Test
 //    @RunAsClient

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
@@ -52,6 +52,8 @@ public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
 
     /**
      * Test a web service call that makes nested calls with a client failure.
+     *
+     * TODO could not test with SmallRye due to https://github.com/smallrye/smallrye-rest-client/issues/11
      */
 //    @Test
 //    @RunAsClient
@@ -71,6 +73,8 @@ public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
      * IDs are correct.
      * @throws InterruptedException Problem executing web service.
      * @throws ExecutionException Thread pool problem.
+     *
+     * TODO smallrye does not support async spec yet!
      */
 //    @Test
 //    @RunAsClient
@@ -88,6 +92,8 @@ public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
      * Same as testMultithreadedNestedSpans but asynchronous client and nested requests.
      * @throws InterruptedException Problem executing web service.
      * @throws ExecutionException Thread pool problem.
+     *
+     * TODO smallrye does not support async spec yet!
      */
 //    @Test
 //    @RunAsClient

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingMpRestClientTests.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck;
+
+import java.util.concurrent.ExecutionException;
+import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class OpenTracingMpRestClientTests extends OpenTracingBaseTests {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return OpenTracingBaseTests.createDeployment();
+    }
+
+    /**
+     * Test a web service call that makes nested calls.
+     */
+    @Test
+    @RunAsClient
+    private void testNestedSpans() {
+        int nestDepth = 1;
+        int nestBreadth = 2;
+        int uniqueId = getRandomNumber();
+        boolean failNest = false;
+        boolean async = false;
+        testNestedSpans(TestServerWebServices.REST_NESTED_MP_REST_CLIENT, nestDepth, nestBreadth, uniqueId, failNest, async);
+    }
+
+    /**
+     * Test a web service call that makes nested calls with a client failure.
+     */
+//    @Test
+//    @RunAsClient
+    private void testNestedSpansWithClientFailure() {
+        int nestDepth = 1;
+        int nestBreadth = 2;
+        int uniqueId = getRandomNumber();
+        boolean failNest = true;
+        boolean async = false;
+        testNestedSpans(TestServerWebServices.REST_NESTED_MP_REST_CLIENT, nestDepth, nestBreadth, uniqueId, failNest, async);
+    }
+
+    /**
+     * Test the nested web service concurrently. A unique ID is generated
+     * in the URL of each request and propagated down the nested spans.
+     * We extract this out of the resulting spans and ensure the unique
+     * IDs are correct.
+     * @throws InterruptedException Problem executing web service.
+     * @throws ExecutionException Thread pool problem.
+     */
+//    @Test
+//    @RunAsClient
+    private void testMultithreadedNestedSpans() throws ExecutionException, InterruptedException {
+        int numberOfCalls = 100;
+        int nestDepth = 1;
+        int nestBreadth = 2;
+        boolean failNest = false;
+        boolean async = false;
+
+        testMultithreadedNestedSpans(TestServerWebServices.REST_NESTED_MP_REST_CLIENT, numberOfCalls, nestDepth, nestBreadth, failNest, async);
+    }
+
+    /**
+     * Same as testMultithreadedNestedSpans but asynchronous client and nested requests.
+     * @throws InterruptedException Problem executing web service.
+     * @throws ExecutionException Thread pool problem.
+     */
+//    @Test
+//    @RunAsClient
+    private void testMultithreadedNestedSpansAsync() throws ExecutionException, InterruptedException {
+        int numberOfCalls = 100;
+        int nestDepth = 1;
+        int nestBreadth = 2;
+        boolean failNest = false;
+        boolean async = true;
+
+        testMultithreadedNestedSpans(TestServerWebServices.REST_NESTED_MP_REST_CLIENT, numberOfCalls, nestDepth, nestBreadth, failNest, async);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
@@ -62,7 +62,6 @@ public interface ClientServices {
     @Path(TestServerWebServices.REST_ERROR)
     CompletionStage<Response> asyncError();
 
-
     @GET
     @Traced(false)
     @Path(TestServerWebServices.REST_SIMPLE_TEST)

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
@@ -30,6 +30,7 @@ import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.opentracing.Traced;
 
 /**
  * @author Pavol Loffay
@@ -47,7 +48,7 @@ public interface ClientServices {
 
     @GET
     @Path(TestServerWebServices.REST_NESTED_MP_REST_CLIENT)
-    CompletionStage<Void> executeNestedAsync(@QueryParam(PARAM_NEST_DEPTH) int nestDepth,
+    CompletionStage<Response> executeNestedAsync(@QueryParam(PARAM_NEST_DEPTH) int nestDepth,
         @QueryParam(PARAM_NEST_BREADTH) int nestBreadth,
         @QueryParam(PARAM_ASYNC) boolean async,
         @QueryParam(PARAM_UNIQUE_ID) String uniqueID,
@@ -59,5 +60,11 @@ public interface ClientServices {
 
     @GET
     @Path(TestServerWebServices.REST_ERROR)
-    CompletionStage<Void> asyncError();
+    CompletionStage<Response> asyncError();
+
+
+    @GET
+    @Traced(false)
+    @Path(TestServerWebServices.REST_SIMPLE_TEST)
+    Response disabledTracing();
 }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck.application;
+
+import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_ASYNC;
+import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_FAIL_NEST;
+import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_NEST_BREADTH;
+import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_NEST_DEPTH;
+import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_UNIQUE_ID;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+/**
+ * @author Pavol Loffay
+ */
+@Path("/")
+public interface ClientServices {
+
+    @GET
+    @Path(TestServerWebServices.REST_NESTED_MP_REST_CLIENT)
+    Response executeNested(@QueryParam(PARAM_NEST_DEPTH) int nestDepth,
+        @QueryParam(PARAM_NEST_BREADTH) int nestBreadth,
+        @QueryParam(PARAM_ASYNC) boolean async,
+        @QueryParam(PARAM_UNIQUE_ID) String uniqueID,
+        @QueryParam(PARAM_FAIL_NEST) boolean failNest);
+}

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServices.java
@@ -25,6 +25,7 @@ import static org.eclipse.microprofile.opentracing.tck.application.TestServerWeb
 import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_NEST_DEPTH;
 import static org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices.PARAM_UNIQUE_ID;
 
+import java.util.concurrent.CompletionStage;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
@@ -43,4 +44,20 @@ public interface ClientServices {
         @QueryParam(PARAM_ASYNC) boolean async,
         @QueryParam(PARAM_UNIQUE_ID) String uniqueID,
         @QueryParam(PARAM_FAIL_NEST) boolean failNest);
+
+    @GET
+    @Path(TestServerWebServices.REST_NESTED_MP_REST_CLIENT)
+    CompletionStage<Void> executeNestedAsync(@QueryParam(PARAM_NEST_DEPTH) int nestDepth,
+        @QueryParam(PARAM_NEST_BREADTH) int nestBreadth,
+        @QueryParam(PARAM_ASYNC) boolean async,
+        @QueryParam(PARAM_UNIQUE_ID) String uniqueID,
+        @QueryParam(PARAM_FAIL_NEST) boolean failNest);
+
+    @GET
+    @Path(TestServerWebServices.REST_ERROR)
+    void error();
+
+    @GET
+    @Path(TestServerWebServices.REST_ERROR)
+    CompletionStage<Void> asyncError();
 }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServicesTracingDisabled.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ClientServicesTracingDisabled.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck.application;
+
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import org.eclipse.microprofile.opentracing.Traced;
+
+/**
+ * @author Pavol Loffay
+ */
+@Traced(false)
+@Path("/")
+public interface ClientServicesTracingDisabled {
+
+    @GET
+    @Path(TestServerWebServices.REST_SIMPLE_TEST)
+    Response restSimpleTest();
+}

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -408,7 +408,7 @@ public class TestServerWebServices {
     @Path(REST_MP_REST_CLIENT_DISABLED_TRACING)
     @Produces(MediaType.TEXT_PLAIN)
     public Response restClientTracingDisabled() throws MalformedURLException {
-        URL webServicesUrl = new URL(baseUrl().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
+        URL webServicesUrl = new URL(getBaseURL().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
         ClientServicesTracingDisabled client = RestClientBuilder.newBuilder()
             .baseUrl(webServicesUrl)
             .build(ClientServicesTracingDisabled.class);
@@ -420,7 +420,7 @@ public class TestServerWebServices {
     @Path(REST_MP_REST_CLIENT_DISABLED_TRACING_METHOD)
     @Produces(MediaType.TEXT_PLAIN)
     public Response restClientMethodTracingDisabled() throws MalformedURLException {
-        URL webServicesUrl = new URL(baseUrl().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
+        URL webServicesUrl = new URL(getBaseURL().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
         ClientServices client = RestClientBuilder.newBuilder()
             .baseUrl(webServicesUrl)
             .build(ClientServices.class);
@@ -443,7 +443,7 @@ public class TestServerWebServices {
 
     private void executeNestedMpRestClient(int depth, int breath, String id, boolean failNest, boolean async)
         throws MalformedURLException, InterruptedException, ExecutionException {
-        URL webServicesUrl = new URL(baseUrl().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
+        URL webServicesUrl = new URL(getBaseURL().toString() + "rest/" + TestServerWebServices.REST_TEST_SERVICE_PATH);
         ClientServices clientServices = RestClientBuilder.newBuilder()
             .baseUrl(webServicesUrl)
             .executorService(Executors.newFixedThreadPool(50))
@@ -488,17 +488,17 @@ public class TestServerWebServices {
     }
 
 
-    public URL baseUrl() {
-        String incomingUrl = uri.getAbsolutePath().toString();
-        int i = incomingUrl.indexOf(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT);
+    public URL getBaseURL() {
+        String incomingURLValue = uri.getAbsolutePath().toString();
+        int i = incomingURLValue.indexOf(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT);
         if (i == -1) {
             throw new RuntimeException("Expecting "
                 + TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT
-                + " in " + incomingUrl);
+                + " in " + incomingURLValue);
         }
         URL incomingURL;
         try {
-            incomingURL = new URL(incomingUrl.substring(0, i));
+            incomingURL = new URL(incomingURLValue.substring(0, i));
         }
         catch (MalformedURLException e) {
             throw new RuntimeException(e);


### PR DESCRIPTION
Resolves #82 

The current proposed solution:
All clients are by default traced. Tracing could be disabled via `Traced(false)` on the client interface or method.

Issues to address:
- [x] ~How to disable, enable tracing? Tracing could be enabled by default and disabled if `@Traced(false)` is present on the interface or vice-versa.  https://github.com/eclipse/microprofile-rest-client/issues/121~ Traced can be applied on interface or method
- [x] ~Async integration probably would be leaking as `AsyncInvocationInterceptor` https://github.com/eclipse/microprofile-rest-client/blob/master/api/src/main/java/org/eclipse/microprofile/rest/client/ext/AsyncInvocationInterceptor.java#L40 does not have a callback to remove applied context. https://github.com/eclipse/microprofile-rest-client/issues/122~ done via AsyncInvocationInterceptor
- [ ] Test the client if it is directly injected - without manually interacting with `RestClientBuilder` (`@Inject @RestClient ServiceInterface`) - not needed the loading of components (interceptors) should be the same as for manually created client
- [x] tests for disabling tracing on method and class.
- [x] test when executor service is overridden 

SmallRye implementation https://github.com/smallrye/smallrye-opentracing/pull/28

Other links to blocking issues, mostly for testing (SmallRye): 
* https://github.com/smallrye/smallrye-rest-client/issues/11
* https://github.com/smallrye/smallrye-rest-client/issues/6
