### PR TITLE
Make client registration consume Configurable

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrar.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrar.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.opentracing;
 import java.util.ServiceLoader;
 import java.util.concurrent.ExecutorService;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configurable;
 
 /**
  * This class registers tracing components into {@link ClientBuilder}.
@@ -61,6 +62,36 @@ public class ClientTracingRegistrar {
      * @return clientBuilder with tracing integration
      */
     public static ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService) {
+        for(ClientTracingRegistrarProvider registrar: ServiceLoader.load(ClientTracingRegistrarProvider.class)) {
+            return registrar.configure(clientBuilder, executorService);
+        }
+        return clientBuilder;
+    }
+
+    /**
+     *  Register tracing components into client builder instance.
+     *
+     * @param clientBuilder client builder
+     * @param <T> typically {@link ClientBuilder}. Behaviour for {@link javax.ws.rs.client.WebTarget} is undefined.
+     * @return clientBuilder with tracing integration
+     */
+    public static <T extends Configurable> T configure(T clientBuilder) {
+        for(ClientTracingRegistrarProvider registrar: ServiceLoader.load(ClientTracingRegistrarProvider.class)) {
+            return registrar.configure(clientBuilder);
+        }
+        return clientBuilder;
+    }
+
+    /**
+     *  Register tracing components into client builder instance.
+     *
+     * @param clientBuilder client builder
+     * @param executorService executorService which will be added to the client. Note that this overrides
+     *      executor service added previously to the client.
+     * @param <T> typically {@link ClientBuilder}. Behaviour for {@link javax.ws.rs.client.WebTarget} is undefined.
+     * @return clientBuilder with tracing integration
+     */
+    public static <T extends Configurable> T configure(T clientBuilder, ExecutorService executorService) {
         for(ClientTracingRegistrarProvider registrar: ServiceLoader.load(ClientTracingRegistrarProvider.class)) {
             return registrar.configure(clientBuilder, executorService);
         }

--- a/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrarProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/ClientTracingRegistrarProvider.java
@@ -21,6 +21,7 @@ package org.eclipse.microprofile.opentracing;
 
 import java.util.concurrent.ExecutorService;
 import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.Configurable;
 
 /**
  * Implementation of this interface will be used to configure {@link ClientBuilder}
@@ -40,6 +41,7 @@ public interface ClientTracingRegistrarProvider {
      *
      * @param clientBuilder Client builder to configure.
      * @return clientBuilder with tracing integration
+     * @deprecated use {@link #configure(Configurable)}
      */
     ClientBuilder configure(ClientBuilder clientBuilder);
 
@@ -49,6 +51,11 @@ public interface ClientTracingRegistrarProvider {
      * @param clientBuilder Client builder to configure.
      * @param executorService Executor service which will be added to the client builder.
      * @return clientBuilder with tracing integration
+     * @deprecated use {@link #configure(Configurable, ExecutorService)}
      */
     ClientBuilder configure(ClientBuilder clientBuilder, ExecutorService executorService);
+
+
+    <T extends Configurable> T  configure(T clientBuilder);
+    <T extends Configurable> T  configure(T clientBuilder, ExecutorService executorService);
 }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/ClientRegistrarTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/ClientRegistrarTests.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright (c) 2018 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck;
+
+import io.opentracing.tag.Tags;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import javax.ws.rs.HttpMethod;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.eclipse.microprofile.opentracing.tck.application.TestClientRegistrarWebServices;
+import org.eclipse.microprofile.opentracing.tck.tracer.TestSpan;
+import org.eclipse.microprofile.opentracing.tck.tracer.TestSpanTree;
+import org.eclipse.microprofile.opentracing.tck.tracer.TestSpanTree.TreeNode;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.testng.annotations.Test;
+
+/**
+ * @author Pavol Loffay
+ */
+public class ClientRegistrarTests extends OpenTracingBaseTests {
+
+    @Deployment
+    public static WebArchive createDeployment() {
+        return OpenTracingBaseTests.createDeployment();
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrar() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CLIENT_BUILDER, false);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarAsync() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CLIENT_BUILDER, true);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarExecutor() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CLIENT_BUILDER_EXECUTOR, false);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarExecutorAsync() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CLIENT_BUILDER_EXECUTOR, true);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarConfigurable() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CONFIGURABLE, false);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarConfigurableAsync() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CONFIGURABLE, true);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarConfigurableExecutor() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CONFIGURABLE_EXECUTOR, false);
+    }
+
+    @Test
+    @RunAsClient
+    public void testClientRegistrarConfigurableExecutorAsync() {
+        testClientRegistrar(TestClientRegistrarWebServices.REST_CONFIGURABLE_EXECUTOR, true);
+    }
+
+    public void testClientRegistrar(String path, boolean async) {
+        Map<String, Object> queryParams = new HashMap<>();
+        if (async) {
+            queryParams.put("async", "true");
+        }
+        Response response = executeRemoteWebServiceRaw(TestClientRegistrarWebServices.REST_SERVICE_PATH,
+            path, queryParams, Status.OK);
+        response.close();
+
+        TestSpanTree spans = executeRemoteWebServiceTracerTree();
+
+        TestSpanTree expectedTree = new TestSpanTree(
+            new TreeNode<>(
+                new TestSpan(
+                    getOperationName(
+                        Tags.SPAN_KIND_SERVER,
+                        HttpMethod.GET,
+                        TestClientRegistrarWebServices.class,
+                        getEndpointMethod(TestClientRegistrarWebServices.class, path)
+                    ),
+                    getExpectedSpanTags(
+                        Tags.SPAN_KIND_SERVER,
+                        HttpMethod.GET,
+                        TestClientRegistrarWebServices.REST_SERVICE_PATH,
+                        path,
+                        queryParams,
+                        Status.OK.getStatusCode(),
+                        JAXRS_COMPONENT
+                    ),
+                    Collections.emptyList()
+                ),
+                new TreeNode<>(
+                    new TestSpan(
+                        getOperationName(
+                            Tags.SPAN_KIND_CLIENT,
+                            HttpMethod.GET,
+                            TestClientRegistrarWebServices.class,
+                            getEndpointMethod(TestClientRegistrarWebServices.class, TestClientRegistrarWebServices.REST_OK)
+                        ),
+                        getExpectedSpanTags(
+                            Tags.SPAN_KIND_CLIENT,
+                            HttpMethod.GET,
+                            TestClientRegistrarWebServices.REST_SERVICE_PATH,
+                            TestClientRegistrarWebServices.REST_OK,
+                            null,
+                            Status.OK.getStatusCode(),
+                            JAXRS_COMPONENT
+                        ),
+                        Collections.emptyList()
+                    ),
+                    new TreeNode<>(
+                        new TestSpan(
+                            getOperationName(
+                                Tags.SPAN_KIND_SERVER,
+                                HttpMethod.GET,
+                                TestClientRegistrarWebServices.class,
+                                getEndpointMethod(TestClientRegistrarWebServices.class, TestClientRegistrarWebServices.REST_OK)
+                            ),
+                            getExpectedSpanTags(
+                                Tags.SPAN_KIND_SERVER,
+                                HttpMethod.GET,
+                                TestClientRegistrarWebServices.REST_SERVICE_PATH,
+                                TestClientRegistrarWebServices.REST_OK,
+                                null,
+                                Status.OK.getStatusCode(),
+                                JAXRS_COMPONENT
+                            ),
+                            Collections.emptyList()
+                        )
+                )
+        )));
+        assertEqualTrees(spans, expectedTree);
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestClientRegistrarWebServices.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestClientRegistrarWebServices.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck.application;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.client.Invocation.Builder;
+import javax.ws.rs.core.Configurable;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.opentracing.ClientTracingRegistrar;
+
+/**
+ * @author Pavol Loffay
+ */
+@Path(TestClientRegistrarWebServices.REST_SERVICE_PATH)
+public class TestClientRegistrarWebServices {
+    public static final String REST_SERVICE_PATH = "testRegistrarServices";
+    public static final String REST_OK = "ok";
+    public static final String REST_CLIENT_BUILDER = "clientBuilder";
+    public static final String REST_CLIENT_BUILDER_EXECUTOR = "clientBuilderExecutor";
+    public static final String REST_CONFIGURABLE = "configurable";
+    public static final String REST_CONFIGURABLE_EXECUTOR = "configurableExecutor";
+
+    @Context
+    private UriInfo uri;
+
+    @GET
+    @Path(REST_OK)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response ok() {
+        return Response.ok().build();
+    }
+
+    /**
+     * Endpoint which uses {@link ClientTracingRegistrar#configure(ClientBuilder)} to create an outbound request
+     * to instrument a client for an outbound request.
+     */
+    @GET
+    @Path(REST_CLIENT_BUILDER)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response clientRegistrar(@QueryParam("async") boolean async)
+        throws ExecutionException, InterruptedException {
+        return executeSimpleEndpoint(instrumentedClient(), async);
+    }
+
+    /**
+     * Endpoint which uses {@link ClientTracingRegistrar#configure(ClientBuilder, java.util.concurrent.ExecutorService)}
+     * to instrument a client for an outbound request.
+     */
+    @GET
+    @Path(REST_CLIENT_BUILDER_EXECUTOR)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response clientRegistrarExecutor(@QueryParam("async") boolean async)
+        throws ExecutionException, InterruptedException {
+        return executeSimpleEndpoint(instrumentedClientExecutor(), async);
+    }
+
+    /**
+     * Endpoint which uses {@link ClientTracingRegistrar#configure(Configurable)}
+     * to instrument a client for an outbound request.
+     */
+    @GET
+    @Path(REST_CONFIGURABLE)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response clientRegistrarConfigurable(@QueryParam("async") boolean async)
+        throws ExecutionException, InterruptedException {
+        return executeSimpleEndpoint(instrumentedConfigurable(), async);
+    }
+
+    /**
+     * Endpoint which uses {@link ClientTracingRegistrar#configure(Configurable, java.util.concurrent.ExecutorService)}
+     * to instrument a client for an outbound request.
+     */
+    @GET
+    @Path(REST_CONFIGURABLE_EXECUTOR)
+    @Produces(MediaType.TEXT_PLAIN)
+    public Response clientRegistrarConfigurableExecutor(@QueryParam("async") boolean async)
+        throws ExecutionException, InterruptedException {
+        return executeSimpleEndpoint(instrumentedConfigurableExecutor(), async);
+    }
+
+    private Response executeSimpleEndpoint(Client client, boolean async)
+        throws ExecutionException, InterruptedException {
+        Builder requestBuilder = client.target(uri.getBaseUri())
+            .path(REST_SERVICE_PATH)
+            .path(REST_OK)
+            .request();
+
+        Response response = async ? requestBuilder.async().get().get() : requestBuilder.get();
+        response.close();
+        client.close();
+        return Response.status(response.getStatus()).build();
+    }
+
+    private Client instrumentedClient() {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        ClientTracingRegistrar.configure(clientBuilder);
+        return clientBuilder.build();
+    }
+
+    private Client instrumentedClientExecutor() {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        ClientTracingRegistrar.configure(clientBuilder, Executors.newFixedThreadPool(10));
+        return clientBuilder.build();
+    }
+
+    private Client instrumentedConfigurable() {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        ClientTracingRegistrar.configure((Configurable) clientBuilder);
+        return clientBuilder.build();
+    }
+
+    private Client instrumentedConfigurableExecutor() {
+        ClientBuilder clientBuilder = ClientBuilder.newBuilder();
+        ClientTracingRegistrar.configure((Configurable) clientBuilder, Executors.newFixedThreadPool(10));
+        return clientBuilder.build();
+    }
+}

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -54,6 +54,7 @@ public class TestWebServicesApplication extends Application {
             TestServerWebServices.class,
             TestServerSkipAllWebServices.class,
             TestServerWebServicesWithOperationName.class,
+            TestClientRegistrarWebServices.class,
             WildcardClassService.class,
             JacksonJsonProvider.class));
     }
@@ -83,6 +84,10 @@ public class TestWebServicesApplication extends Application {
      * @return Query string.
      */
     public static String getQueryString(Map<String, Object> queryParameters) {
+        if (queryParameters.isEmpty()) {
+            return "";
+        }
+
         String result = "?";
 
         String prefix = null;


### PR DESCRIPTION
Resolves #103 

Allow using `ClientTracingRegistrar.configure()` on MP Rest client. It's not fully supported tracing solution for MP rest-client. That will be done in #102. This just makes the current interface work with the mp rest client.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>