### PR TITLE
WIP: Include context path into skip pattern

### DIFF
--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -190,7 +190,7 @@ the method or class is annotated with `@Traced`. The configuration does not disa
 request made from the disabled server endpoint.
 
 The skip pattern is specified as a string with key `mp.opentracing.server.skip-pattern` which has to be
-compliant with `java.util.regex.Pattern`. An example skip pattern might be `mp.opentracing.server.skip-pattern/context/=/health|/metrics.*`
+compliant with `java.util.regex.Pattern`. An example skip pattern might be `mp.opentracing.server.skip-pattern=/app1/foo|/app2/bar.*`
 
 The default value of the skip pattern excludes tracing for default endpoints defined by MicroProfile Health, Metrics and OpenAPI specification.
 

--- a/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
+++ b/spec/src/main/asciidoc/microprofile-opentracing.asciidoc
@@ -184,13 +184,13 @@ If there is an exception object available the implementation SHOULD also add log
 [[server-skip-pattern]]
 ===== Disabling server side tracing
 Server side tracing can be disabled by specifying a skip pattern which is used to match with HTTP path
-`UriInfo.getPath()`. If the regex matches with HTTP path then tracing for the given server
-request is disabled even if the method or class is annotated with `@Traced`.
-The configuration does not disable any outbound request made from the disabled
-server endpoint.
+including context path and excluding query parameters e.g. `UriInfo.getAbsolutePath().getPath()`.
+If the regex matches with HTTP path then tracing for the given server request is disabled even if
+the method or class is annotated with `@Traced`. The configuration does not disable any outbound
+request made from the disabled server endpoint.
 
 The skip pattern is specified as a string with key `mp.opentracing.server.skip-pattern` which has to be
-compliant with `java.util.regex.Pattern`. An example skip pattern might be `mp.opentracing.server.skip-pattern=/health|/metrics.*`
+compliant with `java.util.regex.Pattern`. An example skip pattern might be `mp.opentracing.server.skip-pattern/context/=/health|/metrics.*`
 
 The default value of the skip pattern excludes tracing for default endpoints defined by MicroProfile Health, Metrics and OpenAPI specification.
 

--- a/tck/running_the_tck.asciidoc
+++ b/tck/running_the_tck.asciidoc
@@ -15,10 +15,10 @@
 // limitations under the License.
 //
 
-= Running the Microprofile OpenTracing TCK
+= Running the MicroProfile-OpenTracing TCK
 
-Any Microprofile 1.1 and higher release must pass this test suite.
-The TCK uses `testng`
+Any implementation must pass this test suite.
+The tests expects the test app to be deployed on `/opentracing` root context path.
 
 == Dependencies
 

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingSkipPatternTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingSkipPatternTests.java
@@ -45,7 +45,7 @@ public class OpenTracingSkipPatternTests extends OpenTracingBaseTests {
         private Map<String, String> propMap = new HashMap<>();
 
         {
-            propMap.put("mp.opentracing.server.skip-pattern", "/skipAll/.*|/testServices/skipSimple");
+            propMap.put("mp.opentracing.server.skip-pattern", "/opentracing/rest/skipAll/.*|/opentracing/rest/testServices/skipSimple");
         }
 
         @Override


### PR DESCRIPTION
Resolves #119 

* skip pattern has to include full URL without schema, host, port and query params e.g. `/context/app/endoint`
* test suite expects the test app to be deployed on `/opentracing` context root. 

Signed-off-by: Pavol Loffay <ploffay@redhat.com>