### PR TITLE
Ignore MacOS .DS_Store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test-output
 *.iml
 *.iwl
 *.ipr
+.DS_Store


### PR DESCRIPTION
Add `.DS_Store` to `.gitignore` so git doesn't show it as a untracked file on MacOS

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>