### PR TITLE
Do not fail test when additional data in the tree

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingClientBaseTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingClientBaseTests.java
@@ -404,7 +404,7 @@ public abstract class OpenTracingClientBaseTests extends OpenTracingBaseTests {
                 )
             )
         );
-        assertEqualTrees(spans, expectedTree);
+        assertEqualErrorTrees(spans, expectedTree);
     }
 
     /**

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingSkipPatternTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingSkipPatternTests.java
@@ -161,7 +161,7 @@ public class OpenTracingSkipPatternTests extends OpenTracingBaseTests {
     @RunAsClient
     private void testMetricsBaseNotTraced() {
         Client client = ClientBuilder.newClient();
-        String url = String.format("%s/metrics/base", deploymentURL.toString());
+        String url = String.format("%s/metrics/base", baseUrl());
         debug("Executing " + url);
         client.target(url).request().get();
 


### PR DESCRIPTION
Fixes #131 

1. Create a new assertEqualErrorTrees() to check for returnedTree which expects an error.
1. Switch testAnnotationException() to call assertEqualErrorTrees()
1. Fix the url for `/metrics/base`

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>