### PR TITLE
Remove references from base jax-rs APP to avoid CNFE

### DIFF
--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -43,8 +43,8 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+import org.eclipse.microprofile.opentracing.tck.application.ApplicationUtils;
 import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
-import org.eclipse.microprofile.opentracing.tck.application.TestWebServicesApplication;
 import org.eclipse.microprofile.opentracing.tck.application.TracerWebService;
 import org.eclipse.microprofile.opentracing.tck.tracer.ConsumableTree;
 import org.eclipse.microprofile.opentracing.tck.tracer.TestSpan;
@@ -128,10 +128,10 @@ public abstract class OpenTracingBaseTests extends Arquillian {
      * @return Web service URL
      */
     protected String getWebServiceURL(final String service, final String relativePath, Map<String, Object> queryParameters) {
-        String url = TestWebServicesApplication
+        String url = ApplicationUtils
             .getWebServiceURL(deploymentURL, service, relativePath);
         if (queryParameters != null) {
-            url += TestWebServicesApplication.getQueryString(queryParameters);
+            url += ApplicationUtils.getQueryString(queryParameters);
         }
         return url;
     }

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ApplicationUtils.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/ApplicationUtils.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2017 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.eclipse.microprofile.opentracing.tck.application;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+/**
+ * @author Pavol Loffay
+ */
+public class ApplicationUtils {
+
+    private ApplicationUtils() {
+    }
+
+    /**
+     * The context root of JAXRS web services.
+     */
+    public static final String TEST_WEB_SERVICES_CONTEXT_ROOT = "rest";
+
+    /**
+     * Create web service URL.
+     * @param baseUri Base URI.
+     * @param service Web service path
+     * @param relativePath Web service endpoint
+     * @return Web service URL
+     */
+    public static String getWebServiceURL(final URL baseUri,
+        final String service, final String relativePath) {
+        try {
+            return new URL(baseUri,
+                TEST_WEB_SERVICES_CONTEXT_ROOT + "/"
+                    + service + "/" + relativePath).toString();
+        }
+        catch (MalformedURLException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Convert a map into a query string.
+     * @param queryParameters Map to convert.
+     * @return Query string.
+     */
+    public static String getQueryString(Map<String, Object> queryParameters) {
+        if (queryParameters.isEmpty()) {
+            return "";
+        }
+
+        String result = "?";
+
+        String prefix = null;
+        for (Map.Entry<String, Object> parmEntry : queryParameters
+            .entrySet()) {
+            String parmName = parmEntry.getKey();
+            Object parmValue = parmEntry.getValue();
+
+            if (prefix != null) {
+                result += prefix;
+            }
+            else {
+                prefix = "&";
+            }
+
+            result += urlEncode(parmName);
+
+            if (parmValue != null) {
+                result += "=";
+                result += urlEncode(parmValue.toString());
+            }
+        }
+
+        return result;
+    }
+
+    /**
+     * URL-encode {@code text}.
+     * @param text Text to encode.
+     * @return Encoded text.
+     */
+    public static String urlEncode(String text) {
+        try {
+            return URLEncoder.encode(text, StandardCharsets.UTF_8.name());
+        }
+        catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Create an example RuntimeException used by a web service.
+     * @return New RuntimeException.
+     */
+    public static RuntimeException createExampleRuntimeException() {
+        return new RuntimeException("Example runtime exception");
+    }
+}

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedClass.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestAnnotatedClass.java
@@ -66,6 +66,6 @@ public class TestAnnotatedClass {
      */
     public void annotatedClassMethodImplicitlyTracedWithException() {
         System.out.println("Called annotatedClassMethodImplicitlyTracedWithException");
-        throw TestWebServicesApplication.createExampleRuntimeException();
+        throw ApplicationUtils.createExampleRuntimeException();
     }
 }

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestServerWebServices.java
@@ -236,7 +236,7 @@ public class TestServerWebServices {
     @Path(REST_EXCEPTION)
     @Produces(MediaType.TEXT_PLAIN)
     public Response exception() {
-        throw TestWebServicesApplication.createExampleRuntimeException();
+        throw ApplicationUtils.createExampleRuntimeException();
     }
 
     /**
@@ -417,10 +417,10 @@ public class TestServerWebServices {
             Map<String, Object> requestParameters) {
 
         String incomingUrl = uri.getAbsolutePath().toString();
-        int i = incomingUrl.indexOf(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT);
+        int i = incomingUrl.indexOf(ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT);
         if (i == -1) {
             throw new RuntimeException("Expecting "
-                    + TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT
+                    + ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT
                     + " in " + incomingUrl);
         }
         URL incomingURL;
@@ -430,10 +430,10 @@ public class TestServerWebServices {
         catch (MalformedURLException e) {
             throw new RuntimeException(e);
         }
-        String result = TestWebServicesApplication.getWebServiceURL(incomingURL, servicePath, endpointPath);
+        String result = ApplicationUtils.getWebServiceURL(incomingURL, servicePath, endpointPath);
 
         if ((requestParameters != null) && !requestParameters.isEmpty()) {
-            result += TestWebServicesApplication.getQueryString(requestParameters);
+            result += ApplicationUtils.getQueryString(requestParameters);
         }
 
         return result;

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -18,14 +18,8 @@
  */
 package org.eclipse.microprofile.opentracing.tck.application;
 
-import java.io.UnsupportedEncodingException;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 import javax.ws.rs.ApplicationPath;
@@ -36,13 +30,8 @@ import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 /**
  * Test web services JAXRS application.
  */
-@ApplicationPath(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT)
+@ApplicationPath(ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT)
 public class TestWebServicesApplication extends Application {
-
-    /**
-     * The context root of JAXRS web services.
-     */
-    public static final String TEST_WEB_SERVICES_CONTEXT_ROOT = "rest";
 
     /**
      * {@inheritDoc}
@@ -57,82 +46,5 @@ public class TestWebServicesApplication extends Application {
             TestClientRegistrarWebServices.class,
             WildcardClassService.class,
             JacksonJsonProvider.class));
-    }
-
-    /**
-     * Create web service URL.
-     * @param baseUri Base URI.
-     * @param service Web service path
-     * @param relativePath Web service endpoint
-     * @return Web service URL
-     */
-    public static String getWebServiceURL(final URL baseUri,
-            final String service, final String relativePath) {
-        try {
-            return new URL(baseUri,
-                    TEST_WEB_SERVICES_CONTEXT_ROOT + "/"
-                            + service + "/" + relativePath).toString();
-        }
-        catch (MalformedURLException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Convert a map into a query string.
-     * @param queryParameters Map to convert.
-     * @return Query string.
-     */
-    public static String getQueryString(Map<String, Object> queryParameters) {
-        if (queryParameters.isEmpty()) {
-            return "";
-        }
-
-        String result = "?";
-
-        String prefix = null;
-        for (Map.Entry<String, Object> parmEntry : queryParameters
-                .entrySet()) {
-            String parmName = parmEntry.getKey();
-            Object parmValue = parmEntry.getValue();
-
-            if (prefix != null) {
-                result += prefix;
-            }
-            else {
-                prefix = "&";
-            }
-
-            result += urlEncode(parmName);
-
-            if (parmValue != null) {
-                result += "=";
-                result += urlEncode(parmValue.toString());
-            }
-        }
-
-        return result;
-    }
-
-    /**
-     * URL-encode {@code text}.
-     * @param text Text to encode.
-     * @return Encoded text.
-     */
-    public static String urlEncode(String text) {
-        try {
-            return URLEncoder.encode(text, StandardCharsets.UTF_8.name());
-        }
-        catch (UnsupportedEncodingException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Create an example RuntimeException used by a web service.
-     * @return New RuntimeException.
-     */
-    public static RuntimeException createExampleRuntimeException() {
-        return new RuntimeException("Example runtime exception");
     }
 }

--- a/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
+++ b/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
@@ -19,20 +19,40 @@
 
 package org.eclipse.microprofile.opentracing.tck.rest.client;
 
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+import java.util.Arrays;
+import java.util.HashSet;
 import java.util.Set;
 import javax.ws.rs.ApplicationPath;
-import org.eclipse.microprofile.opentracing.tck.application.TestWebServicesApplication;
+import javax.ws.rs.core.Application;
+import org.eclipse.microprofile.opentracing.tck.application.ApplicationUtils;
+import org.eclipse.microprofile.opentracing.tck.application.TestClientRegistrarWebServices;
+import org.eclipse.microprofile.opentracing.tck.application.TestServerSkipAllWebServices;
+import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
+import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServicesWithOperationName;
+import org.eclipse.microprofile.opentracing.tck.application.TracerWebService;
+import org.eclipse.microprofile.opentracing.tck.application.WildcardClassService;
 
 /**
  * @author Pavol Loffay
+ *
+ * Note that we cannot extend TestWebServicesApplication. We remove it from the deployment
+ * and map a this JAX-RS map to its URL.
+ *
  */
-@ApplicationPath(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT)
-public class RestClientApplication extends TestWebServicesApplication {
+@ApplicationPath(ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT)
+public class RestClientApplication extends Application {
 
     @Override
     public Set<Class<?>> getClasses() {
-        Set<Class<?>> classes = super.getClasses();
-        classes.add(RestClientServices.class);
-        return classes;
+        return new HashSet<>(Arrays.asList(
+            TracerWebService.class,
+            TestServerWebServices.class,
+            TestServerSkipAllWebServices.class,
+            TestServerWebServicesWithOperationName.class,
+            TestClientRegistrarWebServices.class,
+            WildcardClassService.class,
+            RestClientServices.class,
+            JacksonJsonProvider.class));
     }
 }

--- a/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientServices.java
+++ b/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientServices.java
@@ -39,8 +39,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
+import org.eclipse.microprofile.opentracing.tck.application.ApplicationUtils;
 import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
-import org.eclipse.microprofile.opentracing.tck.application.TestWebServicesApplication;
 import org.eclipse.microprofile.rest.client.RestClientBuilder;
 
 /**
@@ -134,10 +134,10 @@ public class RestClientServices {
 
     private URL getBaseURL() {
         String incomingURLValue = uri.getAbsolutePath().toString();
-        int i = incomingURLValue.indexOf(TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT);
+        int i = incomingURLValue.indexOf(ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT);
         if (i == -1) {
             throw new RuntimeException("Expecting "
-                + TestWebServicesApplication.TEST_WEB_SERVICES_CONTEXT_ROOT
+                + ApplicationUtils.TEST_WEB_SERVICES_CONTEXT_ROOT
                 + " in " + incomingURLValue);
         }
         URL incomingURL;


### PR DESCRIPTION
Resolves #142 

The base jaxrs app is removed from deployment in rest-client module
therefore it cannot be referenced from other resource classes.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>