### PR TITLE
Use clientBuilder returned from registrar to perform the test. 

### DIFF
--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestClientRegistrarWebServices.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestClientRegistrarWebServices.java
@@ -36,6 +36,7 @@ import org.eclipse.microprofile.opentracing.ClientTracingRegistrar;
 
 /**
  * @author Pavol Loffay
+ * @author Patrik Dudits
  */
 @Path(TestClientRegistrarWebServices.REST_SERVICE_PATH)
 public class TestClientRegistrarWebServices {
@@ -93,13 +94,13 @@ public class TestClientRegistrarWebServices {
 
     private Client instrumentedClient() {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-        ClientTracingRegistrar.configure(clientBuilder);
+        clientBuilder = ClientTracingRegistrar.configure(clientBuilder);
         return clientBuilder.build();
     }
 
     private Client instrumentedClientExecutor() {
         ClientBuilder clientBuilder = ClientBuilder.newBuilder();
-        ClientTracingRegistrar.configure(clientBuilder, Executors.newFixedThreadPool(10));
+        clientBuilder = ClientTracingRegistrar.configure(clientBuilder, Executors.newFixedThreadPool(10));
         return clientBuilder.build();
     }
 }


### PR DESCRIPTION
Per javadoc, it's the returned client builder that is configured for tracing.