### PR TITLE
Use Jakarta APIs

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -34,12 +34,14 @@
             <version>${osgi-annotation.version}</version>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -102,16 +102,19 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>javax.enterprise</groupId>
-                <artifactId>cdi-api</artifactId>
-                <version>1.2</version>
-                <scope>provided</scope>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>2.0.2</version>
             </dependency>
             <dependency>
-                <groupId>javax.ws.rs</groupId>
-                <artifactId>javax.ws.rs-api</artifactId>
-                <version>2.0.1</version>
-                <scope>provided</scope>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>2.1.4</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>1.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.testng</groupId>

--- a/tck/base/pom.xml
+++ b/tck/base/pom.xml
@@ -38,14 +38,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>javax.json</groupId>
-            <artifactId>javax.json-api</artifactId>
-            <version>1.0</version>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -55,10 +59,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>javax.ws.rs</groupId>
-            <artifactId>javax.ws.rs-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
@@ -73,31 +73,9 @@
             <artifactId>shrinkwrap-resolver-api-maven</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>2.8.2</version>
-        </dependency>
-        <dependency>
             <groupId>io.opentracing</groupId>
             <artifactId>opentracing-api</artifactId>
             <version>0.31.0</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-client</artifactId>
-            <version>3.1.4.Final</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.resteasy</groupId>
-            <artifactId>resteasy-jackson-provider</artifactId>
-            <version>3.1.4.Final</version>
-        </dependency>
-
-        <dependency>
-            <groupId>javax.servlet</groupId>
-            <artifactId>javax.servlet-api</artifactId>
-            <version>3.1.0</version>
-            <scope>provided</scope>
         </dependency>
     </dependencies>
 

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -22,6 +22,7 @@ package org.eclipse.microprofile.opentracing.tck;
 import io.opentracing.tag.Tags;
 import java.io.File;
 import java.lang.reflect.Method;
+import java.math.BigDecimal;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -83,8 +84,7 @@ public abstract class OpenTracingBaseTests extends Arquillian {
 
         File[] files = Maven.resolver()
             .resolve(
-                "io.opentracing:opentracing-api:0.31.0",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0"
+                "io.opentracing:opentracing-api:0.31.0"
             )
             .withTransitivity().asFile();
 
@@ -227,12 +227,12 @@ public abstract class OpenTracingBaseTests extends Arquillian {
         Assert.assertEquals(returnedTree, expectedTree);
     }
 
-    
+
     /**
      * This wrapper method allows for potential post-processing, such as
      * removing tags that we don't care to compare in {@code returnedTree}.
      * This method keeps the error related keys.
-     * 
+     *
      *
      * @param returnedTree The returned tree from the web service.
      * @param expectedTree The simulated tree that we expect.
@@ -266,7 +266,7 @@ public abstract class OpenTracingBaseTests extends Arquillian {
 
         Assert.assertEquals(returnedTree, expectedTree);
     }
-    
+
     /**
      * Print debug message to target/surefire-reports/testng-results.xml.
      *
@@ -343,7 +343,7 @@ public abstract class OpenTracingBaseTests extends Arquillian {
         tags.put(Tags.SPAN_KIND.getKey(), spanKind);
         tags.put(Tags.HTTP_METHOD.getKey(), httpMethod);
         tags.put(Tags.HTTP_URL.getKey(), getWebServiceURL(service, relativePath, queryParameters));
-        tags.put(Tags.HTTP_STATUS.getKey(), httpStatus);
+        tags.put(Tags.HTTP_STATUS.getKey(), new BigDecimal(httpStatus));
         tags.put(Tags.COMPONENT.getKey(), component);
         return tags;
     }

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-
 /**
  * Test web services JAXRS application.
  */
@@ -44,7 +42,6 @@ public class TestWebServicesApplication extends Application {
             TestServerSkipAllWebServices.class,
             TestServerWebServicesWithOperationName.class,
             TestClientRegistrarWebServices.class,
-            WildcardClassService.class,
-            JacksonJsonProvider.class));
+            WildcardClassService.class));
     }
 }

--- a/tck/rest-client/pom.xml
+++ b/tck/rest-client/pom.xml
@@ -42,5 +42,20 @@
             <version>${version.mp.rest.client}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.ws.rs</groupId>
+            <artifactId>jakarta.ws.rs-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.json.bind</groupId>
+            <artifactId>jakarta.json.bind-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
+++ b/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
@@ -19,7 +19,6 @@
 
 package org.eclipse.microprofile.opentracing.tck.rest.client;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -52,7 +51,6 @@ public class RestClientApplication extends Application {
             TestServerWebServicesWithOperationName.class,
             TestClientRegistrarWebServices.class,
             WildcardClassService.class,
-            RestClientServices.class,
-            JacksonJsonProvider.class));
+            RestClientServices.class));
     }
 }


### PR DESCRIPTION
Resolves #161 
Resolves #159 

I have also taken the opportunity to remove the dependency on Jackson and use `jakarta.json.bind-api` instead.

Signed-off-by: Pavol Loffay <ploffay@redhat.com>