### PR TITLE
[1.0-branch] Use HTTPS to download from Maven Central

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ test-output
 *.iml
 *.iwl
 *.ipr
+.DS_Store

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpentracingClientTests.java
@@ -89,10 +89,11 @@ public class OpentracingClientTests extends Arquillian {
     @Deployment
     public static WebArchive createDeployment() {
 
-        File[] files = Maven.resolver()
+        File[] files = Maven.configureResolver()
+                .withRemoteRepo("Maven Central", "https://repo.maven.apache.org/maven2/", "default")
                 .resolve(
-                "io.opentracing:opentracing-api:0.30.0",
-                "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0"
+                    "io.opentracing:opentracing-api:0.30.0",
+                    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0"
                 )
                 .withTransitivity().asFile();
 
@@ -103,7 +104,7 @@ public class OpentracingClientTests extends Arquillian {
 
         return war;
     }
-   
+
     /**
      * Before each test method, clear the tracer.
      * 


### PR DESCRIPTION
Related to #165

Explicitly specify the Maven Central URL https://repo.maven.apache.org/maven2/ to avoid using the default http://repo.maven.apache.org/maven2/