### PR TITLE
[1.3-branch] Remove opentracing-api and jackson in WAR

### DIFF
--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -20,7 +20,6 @@
 package org.eclipse.microprofile.opentracing.tck;
 
 import io.opentracing.tag.Tags;
-import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
@@ -56,7 +55,6 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
@@ -81,18 +79,9 @@ public abstract class OpenTracingBaseTests extends Arquillian {
      */
     public static WebArchive createDeployment() {
 
-        File[] files = Maven.configureResolver()
-                .withRemoteRepo("Maven Central", "https://repo.maven.apache.org/maven2/", "default")
-                .resolve(
-                    "io.opentracing:opentracing-api:0.31.0",
-                    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0"
-                )
-                .withTransitivity().asFile();
-
         WebArchive war = ShrinkWrap.create(WebArchive.class, "opentracing.war")
             .addPackages(true, OpenTracingClientBaseTests.class.getPackage())
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsLibraries(files);
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return war;
     }

--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -25,8 +25,6 @@ import java.util.Set;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-
 /**
  * Test web services JAXRS application.
  */
@@ -44,7 +42,6 @@ public class TestWebServicesApplication extends Application {
             TestServerSkipAllWebServices.class,
             TestServerWebServicesWithOperationName.class,
             TestClientRegistrarWebServices.class,
-            WildcardClassService.class,
-            JacksonJsonProvider.class));
+            WildcardClassService.class));
     }
 }

--- a/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
+++ b/tck/rest-client/src/main/java/org/eclipse/microprofile/opentracing/tck/rest/client/RestClientApplication.java
@@ -19,7 +19,6 @@
 
 package org.eclipse.microprofile.opentracing.tck.rest.client;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -52,7 +51,6 @@ public class RestClientApplication extends Application {
             TestServerWebServicesWithOperationName.class,
             TestClientRegistrarWebServices.class,
             WildcardClassService.class,
-            RestClientServices.class,
-            JacksonJsonProvider.class));
+            RestClientServices.class));
     }
 }


### PR DESCRIPTION
Remove `io.opentracing:opentracing-api:0.31.0` and `com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0` from the WAR file.

Related-to: #175

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>