### PR TITLE
[1.2-branch] Remove opentracing-api and jackson in WAR

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -19,14 +19,13 @@
 
 package org.eclipse.microprofile.opentracing.tck;
 
-import io.opentracing.tag.Tags;
-import java.io.File;
 import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
@@ -34,6 +33,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
 import org.eclipse.microprofile.opentracing.tck.application.TestWebServicesApplication;
 import org.eclipse.microprofile.opentracing.tck.application.TracerWebService;
@@ -46,10 +46,11 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
+
+import io.opentracing.tag.Tags;
 
 /**
  * @author Pavol Loffay
@@ -71,18 +72,9 @@ public abstract class OpenTracingBaseTests extends Arquillian {
      */
     public static WebArchive createDeployment() {
 
-        File[] files = Maven.configureResolver()
-                .withRemoteRepo("Maven Central", "https://repo.maven.apache.org/maven2/", "default")
-                .resolve(
-                    "io.opentracing:opentracing-api:0.31.0",
-                    "com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0"
-                )
-                .withTransitivity().asFile();
-
         WebArchive war = ShrinkWrap.create(WebArchive.class, "opentracing.war")
             .addPackages(true, OpenTracingClientBaseTests.class.getPackage())
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsLibraries(files);
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return war;
     }

--- a/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
+++ b/tck/src/main/java/org/eclipse/microprofile/opentracing/tck/application/TestWebServicesApplication.java
@@ -31,8 +31,6 @@ import java.util.Set;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 
-import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
-
 /**
  * Test web services JAXRS application.
  */
@@ -55,8 +53,7 @@ public class TestWebServicesApplication extends Application {
             TestServerSkipAllWebServices.class,
             TestServerWebServicesWithOperationName.class,
             TestClientRegistrarWebServices.class,
-            WildcardClassService.class,
-            JacksonJsonProvider.class));
+            WildcardClassService.class));
     }
 
     /**


### PR DESCRIPTION
Remove `io.opentracing:opentracing-api:0.31.0` and `com.fasterxml.jackson.jaxrs:jackson-jaxrs-json-provider:2.9.0` from the WAR file.

Related-to: #175

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>