### PR TITLE
Remove opentracing-api in WAR

### DIFF
--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -19,8 +19,6 @@
 
 package org.eclipse.microprofile.opentracing.tck;
 
-import io.opentracing.tag.Tags;
-import java.io.File;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.net.URL;
@@ -37,6 +35,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.Path;
 import javax.ws.rs.client.Client;
@@ -44,6 +43,7 @@ import javax.ws.rs.client.ClientBuilder;
 import javax.ws.rs.client.WebTarget;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.eclipse.microprofile.opentracing.tck.application.ApplicationUtils;
 import org.eclipse.microprofile.opentracing.tck.application.TestServerWebServices;
 import org.eclipse.microprofile.opentracing.tck.application.TracerWebService;
@@ -57,10 +57,11 @@ import org.jboss.arquillian.testng.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.testng.Assert;
 import org.testng.Reporter;
 import org.testng.annotations.BeforeMethod;
+
+import io.opentracing.tag.Tags;
 
 /**
  * @author Pavol Loffay
@@ -82,16 +83,9 @@ public abstract class OpenTracingBaseTests extends Arquillian {
      */
     public static WebArchive createDeployment() {
 
-        File[] files = Maven.resolver()
-            .resolve(
-                "io.opentracing:opentracing-api:0.31.0"
-            )
-            .withTransitivity().asFile();
-
         WebArchive war = ShrinkWrap.create(WebArchive.class, "opentracing.war")
             .addPackages(true, OpenTracingClientBaseTests.class.getPackage())
-            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
-            .addAsLibraries(files);
+            .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
 
         return war;
     }


### PR DESCRIPTION
Remove `io.opentracing:opentracing-api:0.31.0` from the WAR file.

Fixes #175

Signed-off-by: Felix Wong <fmhwong@ca.ibm.com>