### PR TITLE
Update version to 2.0-SNAPSHOT

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -21,7 +21,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.opentracing</groupId>
         <artifactId>microprofile-opentracing-parent</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-opentracing-api</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>org.eclipse.microprofile.opentracing</groupId>
     <artifactId>microprofile-opentracing-parent</artifactId>
-    <version>1.3.2-SNAPSHOT</version>
+    <version>2.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>MicroProfile OpenTracing</name>
     <description>Specification for OpenTracing behavior in MicroProfile</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -20,7 +20,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.opentracing</groupId>
         <artifactId>microprofile-opentracing-parent</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-opentracing-spec</artifactId>

--- a/tck/base/pom.xml
+++ b/tck/base/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>microprofile-opentracing-tck-parent</artifactId>
         <groupId>org.eclipse.microprofile.opentracing</groupId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -25,7 +25,7 @@
         <!-- This is just for now and will not work if the API has a separate release cycle than the rest. -->
         <groupId>org.eclipse.microprofile.opentracing</groupId>
         <artifactId>microprofile-opentracing-parent</artifactId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-opentracing-tck-parent</artifactId>

--- a/tck/rest-client/pom.xml
+++ b/tck/rest-client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>microprofile-opentracing-tck-parent</artifactId>
         <groupId>org.eclipse.microprofile.opentracing</groupId>
-        <version>1.3.2-SNAPSHOT</version>
+        <version>2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
@@ -34,7 +34,7 @@
         <dependency>
             <groupId>org.eclipse.microprofile.opentracing</groupId>
             <artifactId>microprofile-opentracing-tck</artifactId>
-            <version>1.3.2-SNAPSHOT</version>
+            <version>2.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.microprofile.rest.client</groupId>


### PR DESCRIPTION
It is somehow confusing that a branch for 1.3.x exits, but master is also 1.3.x. Plus, master was at 1.3.2-SNAPSHOT and 1.3.3 was already released.