### PR TITLE
Bump MicroProfile-Config to 1.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
         <autorelease>false</autorelease>
 
-        <version.mp.config>1.3</version.mp.config>
+        <version.mp.config>1.4</version.mp.config>
         <version.mp.rest.client>1.2</version.mp.rest.client>
         <version.opentracing>0.33.0</version.opentracing>
         <!-- Versions of API dependencies -->


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

Related to #191 


Bump MP-Config to 1.4. I assume Config 1.4 will be pulled into MP 4.0. Is that right @kenfinnigan or @Emily-Jiang? 