### PR TITLE
Bump OSGI annotation version to 2.0

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/opentracing/package-info.java
+++ b/api/src/main/java/org/eclipse/microprofile/opentracing/package-info.java
@@ -26,5 +26,5 @@
  * @author <a href="mailto:steve.m.fontes@gmail.com">Steve Fontes</a>
  */
 
-@org.osgi.annotation.versioning.Version("1.0")
+@org.osgi.annotation.versioning.Version("2.0")
 package org.eclipse.microprofile.opentracing;


### PR DESCRIPTION
Signed-off-by: Pavol Loffay <ploffay@redhat.com>

@Emily-Jiang could you please review? 

the RC2 release failed probably on this https://ci.eclipse.org/microprofile/job/MicroProfile%20Releases/413/

```
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Reactor Summary for MicroProfile OpenTracing 2.0-RC2:
[INFO] [INFO] 
[INFO] [INFO] MicroProfile OpenTracing ........................... SUCCESS [ 23.056 s]
[INFO] [INFO] MicroProfile OpenTracing API ....................... FAILURE [  7.838 s]
[INFO] [INFO] MicroProfile OpenTracing TCK ....................... SKIPPED
[INFO] [INFO] microprofile-opentracing-tck ....................... SKIPPED
[INFO] [INFO] microprofile-opentracing-tck-rest-client ........... SKIPPED
[INFO] [INFO] MicroProfile OpenTracing Specification ............. SKIPPED
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] BUILD FAILURE
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [INFO] Total time:  38.989 s
[INFO] [INFO] Finished at: 2020-07-29T08:02:02Z
[INFO] [INFO] ------------------------------------------------------------------------
[INFO] [ERROR] Failed to execute goal biz.aQute.bnd:bnd-baseline-maven-plugin:3.5.0:baseline (baseline) on project microprofile-opentracing-api: An error occurred while calculating the baseline: The baselining plugin detected versioning errors -> [Help 1]
[INFO] [ERROR] 
[INFO] [ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[INFO] [ERROR] Re-run Maven using the -X switch to enable full debug logging.
[INFO] [ERROR] 
[INFO] [ERROR] For more information about the errors and possible solutions, please read the following articles:
[INFO] [ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
[INFO] [ERROR] 
[INFO] [ERROR] After correcting the problems, you can resume the build with the command
[INFO] [ERROR]   mvn <args> -rf :microprofile-opentracing-api
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for MicroProfile OpenTracing 2.1-SNAPSHOT:
[INFO] 
[INFO] MicroProfile OpenTracing ........................... FAILURE [ 44.508 s]
[INFO] MicroProfile OpenTracing API ....................... SKIPPED
[INFO] MicroProfile OpenTracing TCK ....................... SKIPPED
[INFO] microprofile-opentracing-tck ....................... SKIPPED
[INFO] microprofile-opentracing-tck-rest-client ........... SKIPPED
[INFO] MicroProfile OpenTracing Specification ............. SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  52.048 s
[INFO] Finished at: 2020-07-29T08:02:02Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-release-plugin:2.5.3:prepare (default-cli) on project microprofile-opentracing-parent: Maven execution failed, exit code: '1' -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```