### PR TITLE
Fix baseline maven plugin configuration

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -64,11 +64,6 @@
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
                 <version>2.4.1</version>
-                <configuration>
-                    <base>
-                        <version>1.3</version>
-                    </base>
-                </configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -92,7 +87,11 @@
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-baseline-maven-plugin</artifactId>
                 <version>3.5.0</version>
-
+                <configuration>
+                    <base>
+                        <version>1.3</version>
+                    </base>
+                </configuration>
                 <executions>
                     <execution>
                         <id>baseline</id>


### PR DESCRIPTION
This PR fixes https://github.com/eclipse/microprofile-opentracing/pull/202

The build was still failing on https://ci.eclipse.org/microprofile/job/MicroProfile%20Releases/415/console
```
[INFO] [INFO] The baseline version was found to be 2.0-RC1
[INFO] [ERROR] The bundle version change (2.0.0 to 2.0.0) is too low, the new version must be at least 2.0.1
```

This is the correct configuration according to https://github.com/eclipse/microprofile-metrics/blob/master/api/pom.xml#L95