### PR TITLE
Update BND plugin

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -109,7 +109,7 @@
             <plugin>
                 <groupId>biz.aQute.bnd</groupId>
                 <artifactId>bnd-maven-plugin</artifactId>
-                <version>2.4.1</version>
+                <version>5.0.0</version>
                 <executions>
                     <execution>
                         <goals>


### PR DESCRIPTION
Update BND to 5.0.0 which is used by most other spec projects. The very old 2.4 version has an issue that breaks the build in our productization environment.