### PR TITLE
Don't use BigDecimal for Expected HTTP Status Tag in TCK

### DIFF
--- a/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
+++ b/tck/base/src/main/java/org/eclipse/microprofile/opentracing/tck/OpenTracingBaseTests.java
@@ -20,7 +20,6 @@
 package org.eclipse.microprofile.opentracing.tck;
 
 import java.lang.reflect.Method;
-import java.math.BigDecimal;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -368,7 +367,7 @@ public abstract class OpenTracingBaseTests extends Arquillian {
         tags.put(Tags.SPAN_KIND.getKey(), spanKind);
         tags.put(Tags.HTTP_METHOD.getKey(), httpMethod);
         tags.put(Tags.HTTP_URL.getKey(), getWebServiceURL(service, relativePath, queryParameters));
-        tags.put(Tags.HTTP_STATUS.getKey(), new BigDecimal(httpStatus));
+        tags.put(Tags.HTTP_STATUS.getKey(), httpStatus);
         tags.put(Tags.COMPONENT.getKey(), component);
         return tags;
     }


### PR DESCRIPTION
Using BigDecimal can mess with the `assertEqualTrees` comparison.
In Payara the `http.status_code` is returned as an Integer, causing the `Assert.assertEquals(returnedTree, expectedTree);` comparison to fail even though the actual JSON is correct (`expectedTree.toString().equals(returnedTree.toString())` returns true)

The BigDecimal expectation got introduced in 2.0, and afaik isn't mandated by the spec and actually doesn't serve any purpose over a standard Integer.